### PR TITLE
patch CI failure due to unconditional Qiskit deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ testpaths = ["test/python"]
 addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
 log_cli_level = "INFO"
 xfail_strict = true
-filterwarnings = ["error", 'ignore:Conversion.*to a scalar is deprecated.*:DeprecationWarning:qiskit:']
+filterwarnings = ["error", 'ignore:Conversion.*to a scalar is deprecated.*:DeprecationWarning:qiskit:', 'ignore:.*qiskit.__qiskit_version__.*:DeprecationWarning:qiskit:']
 
 [tool.coverage.run]
 source = ["mqt.qmap"]


### PR DESCRIPTION
## Description

Fixes CI. The newest Qiskit version introduced a new deprecation warning for some version attribute and, for some reason, that warning trips up pytest without our code actually using the deprecated attribute.Fixes # (issue)

## Checklist:


- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
