### PR TITLE
🐛 Fix broken `manylinux` wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ test-skip = "cp312-*"  # Qiskit Terra does not support Python 3.12 yet
 build-frontend = "build"
 
 [tool.cibuildwheel.linux]
-environment = { Z3_ROOT="/opt/python/cp311-cp311/lib/python3.11/site-packages/z3" }
+environment = { Z3_ROOT="/opt/python/cp311-cp311/lib/python3.11/site-packages/z3", DEPLOY="ON" }
 before-all = "/opt/python/cp311-cp311/bin/pip install z3-solver==4.11.2"
 repair-wheel-command = [
     "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp311-cp311/lib/python3.11/site-packages/z3/lib",


### PR DESCRIPTION
## Description

Due to the way Linux wheels are built by cibuildwheel (in a manylinux docker container), environment varaiables are not passed down to the container. As a result the `CI` environment variable is not defined in the docker container, which is used to flip on the `DEPLOY` CMake setting automatically.
This has lead to manylinux wheels being built with `-march=native` that might produce errors like
```console
Illegal instruction (core dumped)
```
when trying to import the respective packages.

This PR fixes this by making sure that `DEPLOY="ON"` within cibuildwheel.

Fixes #375 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
