### PR TITLE
🩹 📝 removes the `hmtl_baseurl` setting from RtD config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,7 +132,6 @@ napoleon_numpy_docstring = False
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = "furo"
-html_baseurl = "https://mqt.readthedocs.io/project/qmap/en/latest/"
 html_static_path = ["_static"]
 html_theme_options = {
     "light_logo": "mqt_dark.png",


### PR DESCRIPTION
## Description

Sphinx recommends not setting `hmtl_baseurl` so that RtD can figure it out on its own.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.