### PR TITLE
Fixing minor bug in `disjoint_2q_block` Layering and adding option `add_barriers_between_layers`

### DIFF
--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -197,7 +197,22 @@ protected:
   void processDisjointQubitLayer(
       std::array<std::optional<std::size_t>, MAX_DEVICE_QUBITS>& lastLayer,
       const std::optional<std::uint16_t>& control, std::uint16_t target,
-      qc::Operation* gate, bool collect2qBlocks);
+      qc::Operation* gate);
+  
+  /**
+   * Similar to processDisjointQubitLayer, but instead of treating each gate
+   * individually, gates are collected in 2Q-blocks, which are layered 
+   * disjointly to each other
+   *
+   * @param lastLayer the array storing the last layer each qubit is used in
+   * @param control the (potential) control qubit of the gate
+   * @param target the target qubit of the gate
+   * @param gate the gate to be added to the layer
+   */
+  void processDisjoint2qBlockLayer(
+      std::array<std::optional<std::size_t>, MAX_DEVICE_QUBITS>& lastLayer,
+      const std::optional<std::uint16_t>& control, std::uint16_t target,
+      qc::Operation* gate);
 
   /**
    * @brief Get the index of the next layer after the given index containing a

--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -198,10 +198,10 @@ protected:
       std::array<std::optional<std::size_t>, MAX_DEVICE_QUBITS>& lastLayer,
       const std::optional<std::uint16_t>& control, std::uint16_t target,
       qc::Operation* gate);
-  
+
   /**
    * Similar to processDisjointQubitLayer, but instead of treating each gate
-   * individually, gates are collected in 2Q-blocks, which are layered 
+   * individually, gates are collected in 2Q-blocks, which are layered
    * disjointly to each other
    *
    * @param lastLayer the array storing the last layer each qubit is used in

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -29,6 +29,7 @@ struct Configuration {
 
   bool addMeasurementsToMappedCircuit = true;
   bool swapOnFirstLayer               = false;
+  bool addBarriersBetweenLayers       = false;
 
   bool        verbose = false;
   bool        debug   = false;

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -35,18 +35,11 @@ Mapper::Mapper(qc::QuantumComputation quantumComputation, Architecture& arch)
 void Mapper::processDisjointQubitLayer(
     std::array<std::optional<std::size_t>, MAX_DEVICE_QUBITS>& lastLayer,
     const std::optional<std::uint16_t>& control, const std::uint16_t target,
-    qc::Operation* gate, bool collect2qBlocks) {
+    qc::Operation* gate) {
   std::size_t layer = 0;
   if (!control.has_value()) {
     if (lastLayer.at(target).has_value()) {
-      layer = *lastLayer.at(target);
-      // single qubit gates can always be added to the last 2Q block
-      if (!collect2qBlocks) {
-        layer++;
-      }
-    }
-    if (!collect2qBlocks) {
-      lastLayer.at(target) = layer;
+      layer = *lastLayer.at(target) + 1;
     }
     lastLayer.at(target) = layer;
   } else {
@@ -59,15 +52,50 @@ void Mapper::processDisjointQubitLayer(
       layer = *lastLayer.at(*control) + 1;
     } else {
       layer = std::max(*lastLayer.at(*control), *lastLayer.at(target)) + 1;
+    }
+    lastLayer.at(*control) = layer;
+    lastLayer.at(target)   = layer;
+  }
 
-      if (collect2qBlocks &&
-          (*lastLayer.at(*control) == *lastLayer.at(target))) {
+  if (layers.size() <= layer) {
+    layers.emplace_back();
+  }
+  if (control.has_value()) {
+    layers.at(layer).emplace_back(*control, target, gate);
+  } else {
+    layers.at(layer).emplace_back(-1, target, gate);
+  }
+}
+
+void Mapper::processDisjoint2qBlockLayer(
+    std::array<std::optional<std::size_t>, MAX_DEVICE_QUBITS>& lastLayer,
+    const std::optional<std::uint16_t>& control, const std::uint16_t target,
+    qc::Operation* gate) {
+  std::size_t layer = 0;
+  if (!control.has_value()) {
+    // single qubit gates can always be added to the last 2Q block and should
+    // affect placings of future 2Q blocks
+    if (lastLayer.at(target).has_value()) {
+      layer = *lastLayer.at(target);
+    }
+  } else {
+    if (!lastLayer.at(*control).has_value() &&
+        !lastLayer.at(target).has_value()) {
+      layer = 0;
+    } else if (!lastLayer.at(*control).has_value()) {
+      layer = *lastLayer.at(target) + 1;
+    } else if (!lastLayer.at(target).has_value()) {
+      layer = *lastLayer.at(*control) + 1;
+    } else {
+      layer = std::max(*lastLayer.at(*control), *lastLayer.at(target)) + 1;
+
+      if (*lastLayer.at(*control) == *lastLayer.at(target)) {
         for (auto& g : layers.at(layer - 1)) {
           if ((g.control == *control && g.target == target) ||
               (g.control == target && g.target == *control)) {
             // if last layer contained gate with equivalent qubit set, use that
             // layer
-            layer--;
+            --layer;
             break;
           }
         }
@@ -134,10 +162,10 @@ void Mapper::createLayers() {
       }
       break;
     case Layering::DisjointQubits:
-      processDisjointQubitLayer(lastLayer, control, target, gate.get(), false);
+      processDisjointQubitLayer(lastLayer, control, target, gate.get());
       break;
     case Layering::Disjoint2qBlocks:
-      processDisjointQubitLayer(lastLayer, control, target, gate.get(), true);
+      processDisjoint2qBlockLayer(lastLayer, control, target, gate.get());
       break;
     case Layering::OddGates:
       // every other gate is put in a new layer

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -74,7 +74,7 @@ void Mapper::processDisjoint2qBlockLayer(
   std::size_t layer = 0;
   if (!control.has_value()) {
     // single qubit gates can always be added to the last 2Q block and should
-    // affect placings of future 2Q blocks
+    // not affect placings of future 2Q blocks
     if (lastLayer.at(target).has_value()) {
       layer = *lastLayer.at(target);
     }

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -347,6 +347,11 @@ void HeuristicMapper::routeCircuit() {
       printLocations(std::clog);
       printQubits(std::clog);
     }
+    
+    if (layerIndex != 0 && config.addBarriersBetweenLayers) {
+      qcMapped.barrier();
+      gateidx++;
+    }
 
     // initial layer needs no swaps
     if (layerIndex != 0 || config.swapOnFirstLayer) {

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -347,7 +347,7 @@ void HeuristicMapper::routeCircuit() {
       printLocations(std::clog);
       printQubits(std::clog);
     }
-    
+
     if (layerIndex != 0 && config.addBarriersBetweenLayers) {
       qcMapped.barrier();
       gateidx++;

--- a/src/mqt/qmap/compile.py
+++ b/src/mqt/qmap/compile.py
@@ -81,6 +81,7 @@ def compile(  # noqa: A001
     pre_mapping_optimizations: bool = True,
     post_mapping_optimizations: bool = True,
     add_measurements_to_mapped_circuit: bool = True,
+    add_barriers_between_layers: bool = False,
     verbose: bool = False,
     debug: bool = False,
     visualizer: SearchVisualizer | None = None,
@@ -113,6 +114,7 @@ def compile(  # noqa: A001
         pre_mapping_optimizations: Run pre-mapping optimizations. Defaults to True.
         post_mapping_optimizations: Run post-mapping optimizations. Defaults to True.
         add_measurements_to_mapped_circuit: Whether to add measurements at the end of the mapped circuit. Defaults to True.
+        add_barriers_between_layers: Whether to add barriers between layers to make them apparent after mapping. Defaults to False.
         verbose: Print more detailed information during the mapping process. Defaults to False.
         debug: Gather additional information during the mapping process (e.g. number of generated nodes, branching factors, ...). Defaults to False.
         visualizer: A SearchVisualizer object to log the search process to. Defaults to None.
@@ -159,6 +161,7 @@ def compile(  # noqa: A001
     config.pre_mapping_optimizations = pre_mapping_optimizations
     config.post_mapping_optimizations = post_mapping_optimizations
     config.add_measurements_to_mapped_circuit = add_measurements_to_mapped_circuit
+    config.add_barriers_between_layers = add_barriers_between_layers
     config.verbose = verbose
     config.debug = debug
     if visualizer is not None and visualizer.data_logging_path is not None:

--- a/src/mqt/qmap/pyqmap.pyi
+++ b/src/mqt/qmap/pyqmap.pyi
@@ -110,6 +110,7 @@ class CommanderGrouping:
 
 class Configuration:
     add_measurements_to_mapped_circuit: bool
+    add_barriers_between_layers: bool
     admissible_heuristic: bool
     consider_fidelity: bool
     commander_grouping: CommanderGrouping

--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -220,6 +220,8 @@ PYBIND11_MODULE(pyqmap, m) {
                      &Configuration::postMappingOptimizations)
       .def_readwrite("add_measurements_to_mapped_circuit",
                      &Configuration::addMeasurementsToMappedCircuit)
+      .def_readwrite("add_barriers_between_layers",
+                     &Configuration::addBarriersBetweenLayers)
       .def("json", &Configuration::json)
       .def("__repr__", &Configuration::toString);
 

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -87,18 +87,17 @@ TEST(Functionality, LayeringTest) {
   for (size_t i = 0; i < 3; ++i) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
-  
+
   Configuration settings{};
-  settings.initialLayout            = InitialLayout::Dynamic;
-  settings.preMappingOptimizations  = false;
-  settings.postMappingOptimizations = false;
+  settings.initialLayout                  = InitialLayout::Dynamic;
+  settings.preMappingOptimizations        = false;
+  settings.postMappingOptimizations       = false;
   settings.addMeasurementsToMappedCircuit = true;
-  settings.addBarriersBetweenLayers = true;
-  settings.automaticLayerSplits     = false;
-  
-  
+  settings.addBarriersBetweenLayers       = true;
+  settings.automaticLayerSplits           = false;
+
   // Disjoint2qBlocks
-  auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  auto mapper       = std::make_unique<HeuristicMapper>(qc, architecture);
   settings.layering = Layering::Disjoint2qBlocks;
   mapper->map(settings);
   auto result = mapper->getResults();
@@ -116,16 +115,16 @@ TEST(Functionality, LayeringTest) {
     }
   }
   EXPECT_EQ(barriers, result.input.layers);
-  
+
   // DisjointQubits
-  mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  mapper            = std::make_unique<HeuristicMapper>(qc, architecture);
   settings.layering = Layering::DisjointQubits;
   mapper->map(settings);
   result = mapper->getResults();
   EXPECT_EQ(result.input.layers, 3);
   // get mapped circuit
   qcMapped = qc::QuantumComputation();
-  qasm = std::stringstream{};
+  qasm     = std::stringstream{};
   mapper->dumpResult(qasm, qc::Format::OpenQASM);
   qcMapped.import(qasm, qc::Format::OpenQASM);
   // check barrier count
@@ -136,16 +135,16 @@ TEST(Functionality, LayeringTest) {
     }
   }
   EXPECT_EQ(barriers, result.input.layers);
-  
+
   // IndividualGates
-  mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  mapper            = std::make_unique<HeuristicMapper>(qc, architecture);
   settings.layering = Layering::IndividualGates;
   mapper->map(settings);
   result = mapper->getResults();
   EXPECT_EQ(result.input.layers, 6);
   // get mapped circuit
   qcMapped = qc::QuantumComputation();
-  qasm = std::stringstream{};
+  qasm     = std::stringstream{};
   mapper->dumpResult(qasm, qc::Format::OpenQASM);
   qcMapped.import(qasm, qc::Format::OpenQASM);
   // check barrier count

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -731,16 +731,16 @@ protected:
     for (size_t i = 0; i < 3; ++i) {
       qc.measure(static_cast<qc::Qubit>(i), i);
     }
-    
+
     arch = Architecture{4, {{0, 1}, {1, 2}, {2, 3}}};
-    
+
     settings.initialLayout                  = InitialLayout::Dynamic;
     settings.preMappingOptimizations        = false;
     settings.postMappingOptimizations       = false;
     settings.addMeasurementsToMappedCircuit = true;
     settings.addBarriersBetweenLayers       = true;
     settings.automaticLayerSplits           = false;
-    
+
     mapper = std::make_unique<HeuristicMapper>(qc, arch);
   }
 };

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -72,91 +72,6 @@ TEST(Functionality, NodeCostCalculation) {
               tolerance);
 }
 
-TEST(Functionality, LayeringTest) {
-  Architecture architecture{4, {{0, 1}, {1, 2}, {2, 3}}};
-
-  qc::QuantumComputation qc{4, 4};
-  qc.x(0);
-  qc.x(1);
-  qc.cx(qc::Control{0}, 1);
-  qc.cx(qc::Control{2}, 3);
-  qc.cx(qc::Control{1}, 2);
-  qc.x(3);
-
-  qc.barrier({0, 1, 2});
-  for (size_t i = 0; i < 3; ++i) {
-    qc.measure(static_cast<qc::Qubit>(i), i);
-  }
-
-  Configuration settings{};
-  settings.initialLayout                  = InitialLayout::Dynamic;
-  settings.preMappingOptimizations        = false;
-  settings.postMappingOptimizations       = false;
-  settings.addMeasurementsToMappedCircuit = true;
-  settings.addBarriersBetweenLayers       = true;
-  settings.automaticLayerSplits           = false;
-
-  // Disjoint2qBlocks
-  auto mapper       = std::make_unique<HeuristicMapper>(qc, architecture);
-  settings.layering = Layering::Disjoint2qBlocks;
-  mapper->map(settings);
-  auto result = mapper->getResults();
-  EXPECT_EQ(result.input.layers, 2);
-  // get mapped circuit
-  auto              qcMapped = qc::QuantumComputation();
-  std::stringstream qasm{};
-  mapper->dumpResult(qasm, qc::Format::OpenQASM);
-  qcMapped.import(qasm, qc::Format::OpenQASM);
-  // check barrier count
-  std::size_t barriers = 0;
-  for (const auto& op : qcMapped) {
-    if (op->getType() == qc::Barrier) {
-      ++barriers;
-    }
-  }
-  EXPECT_EQ(barriers, result.input.layers);
-
-  // DisjointQubits
-  mapper            = std::make_unique<HeuristicMapper>(qc, architecture);
-  settings.layering = Layering::DisjointQubits;
-  mapper->map(settings);
-  result = mapper->getResults();
-  EXPECT_EQ(result.input.layers, 3);
-  // get mapped circuit
-  qcMapped = qc::QuantumComputation();
-  qasm     = std::stringstream{};
-  mapper->dumpResult(qasm, qc::Format::OpenQASM);
-  qcMapped.import(qasm, qc::Format::OpenQASM);
-  // check barrier count
-  barriers = 0;
-  for (const auto& op : qcMapped) {
-    if (op->getType() == qc::Barrier) {
-      ++barriers;
-    }
-  }
-  EXPECT_EQ(barriers, result.input.layers);
-
-  // IndividualGates
-  mapper            = std::make_unique<HeuristicMapper>(qc, architecture);
-  settings.layering = Layering::IndividualGates;
-  mapper->map(settings);
-  result = mapper->getResults();
-  EXPECT_EQ(result.input.layers, 6);
-  // get mapped circuit
-  qcMapped = qc::QuantumComputation();
-  qasm     = std::stringstream{};
-  mapper->dumpResult(qasm, qc::Format::OpenQASM);
-  qcMapped.import(qasm, qc::Format::OpenQASM);
-  // check barrier count
-  barriers = 0;
-  for (const auto& op : qcMapped) {
-    if (op->getType() == qc::Barrier) {
-      ++barriers;
-    }
-  }
-  EXPECT_EQ(barriers, result.input.layers);
-}
-
 TEST(Functionality, HeuristicBenchmark) {
   /*
       3
@@ -795,6 +710,99 @@ TEST(Functionality, DataLogger) {
            << results.input.layers
            << ".csv should not exist, as there are not that many layers";
   }
+}
+
+class LayeringTest : public testing::Test {
+protected:
+  qc::QuantumComputation           qc{};
+  Architecture                     arch{};
+  std::unique_ptr<HeuristicMapper> mapper;
+  Configuration                    settings{};
+
+  void SetUp() override {
+    qc = qc::QuantumComputation{4, 4};
+    qc.x(0);
+    qc.x(1);
+    qc.cx(qc::Control{0}, 1);
+    qc.cx(qc::Control{2}, 3);
+    qc.cx(qc::Control{1}, 2);
+    qc.x(3);
+    qc.barrier({0, 1, 2});
+    for (size_t i = 0; i < 3; ++i) {
+      qc.measure(static_cast<qc::Qubit>(i), i);
+    }
+    
+    arch = Architecture{4, {{0, 1}, {1, 2}, {2, 3}}};
+    
+    settings.initialLayout                  = InitialLayout::Dynamic;
+    settings.preMappingOptimizations        = false;
+    settings.postMappingOptimizations       = false;
+    settings.addMeasurementsToMappedCircuit = true;
+    settings.addBarriersBetweenLayers       = true;
+    settings.automaticLayerSplits           = false;
+    
+    mapper = std::make_unique<HeuristicMapper>(qc, arch);
+  }
+};
+
+TEST_F(LayeringTest, Disjoint2qBlocks) {
+  settings.layering = Layering::Disjoint2qBlocks;
+  mapper->map(settings);
+  auto result = mapper->getResults();
+  EXPECT_EQ(result.input.layers, 2);
+  // get mapped circuit
+  auto              qcMapped = qc::QuantumComputation();
+  std::stringstream qasm{};
+  mapper->dumpResult(qasm, qc::Format::OpenQASM);
+  qcMapped.import(qasm, qc::Format::OpenQASM);
+  // check barrier count
+  std::size_t barriers = 0;
+  for (const auto& op : qcMapped) {
+    if (op->getType() == qc::Barrier) {
+      ++barriers;
+    }
+  }
+  EXPECT_EQ(barriers, result.input.layers);
+}
+
+TEST_F(LayeringTest, DisjointQubits) {
+  settings.layering = Layering::DisjointQubits;
+  mapper->map(settings);
+  auto result = mapper->getResults();
+  EXPECT_EQ(result.input.layers, 3);
+  // get mapped circuit
+  auto              qcMapped = qc::QuantumComputation();
+  std::stringstream qasm{};
+  mapper->dumpResult(qasm, qc::Format::OpenQASM);
+  qcMapped.import(qasm, qc::Format::OpenQASM);
+  // check barrier count
+  std::size_t barriers = 0;
+  for (const auto& op : qcMapped) {
+    if (op->getType() == qc::Barrier) {
+      ++barriers;
+    }
+  }
+  EXPECT_EQ(barriers, result.input.layers);
+}
+
+TEST_F(LayeringTest, IndividualGates) {
+  settings.layering = Layering::IndividualGates;
+  mapper->map(settings);
+  auto result = mapper->getResults();
+  EXPECT_EQ(result.input.layers, 6);
+  // get mapped circuit
+  auto              qcMapped = qc::QuantumComputation();
+  std::stringstream qasm{};
+  mapper->dumpResult(qasm, qc::Format::OpenQASM);
+  qcMapped.import(qasm, qc::Format::OpenQASM);
+  // check barrier count
+  std::size_t barriers = 0;
+  for (const auto& op : qcMapped) {
+    if (op->getType() == qc::Barrier) {
+      ++barriers;
+    }
+  }
+  EXPECT_EQ(barriers, result.input.layers);
 }
 
 class HeuristicTest5Q : public testing::TestWithParam<std::string> {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -72,6 +72,52 @@ TEST(Functionality, NodeCostCalculation) {
               tolerance);
 }
 
+TEST(Functionality, InsertBarriersBetweenLayers) {
+  Architecture architecture{3, {{0, 1}, {1, 2}}};
+
+  qc::QuantumComputation qc{3, 3};
+  qc.x(0);
+  qc.cx(qc::Control{0}, 1);
+  qc.cx(qc::Control{0}, 2);
+  qc.cx(qc::Control{1}, 2);
+  qc.x(1);
+
+  qc.barrier({0, 1, 2});
+  for (size_t i = 0; i < 3; ++i) {
+    qc.measure(static_cast<qc::Qubit>(i), i);
+  }
+  
+  const auto    mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  Configuration settings{};
+  settings.layering                 = Layering::Disjoint2qBlocks;
+  settings.initialLayout            = InitialLayout::Dynamic;
+  settings.preMappingOptimizations  = true;
+  settings.postMappingOptimizations = true;
+  settings.lookahead                = true;
+  settings.nrLookaheads             = 15;
+  settings.addMeasurementsToMappedCircuit = true;
+  settings.addBarriersBetweenLayers = true;
+  mapper->map(settings);
+  
+  // get the resulting circuit
+  auto              qcMapped = qc::QuantumComputation();
+  std::stringstream qasm{};
+  mapper->dumpResult(qasm, qc::Format::OpenQASM);
+  qcMapped.import(qasm, qc::Format::OpenQASM);
+  
+  qasm = std::stringstream();
+  mapper->dumpResult(qasm, qc::Format::OpenQASM);
+  std::cout << qasm.str() << std::endl;
+  
+  std::size_t barriers = 0;
+  for (const auto& op : qcMapped) {
+    if (op->getType() == qc::Barrier) {
+      ++barriers;
+    }
+  }
+  EXPECT_EQ(barriers, 3);
+}
+
 TEST(Functionality, HeuristicBenchmark) {
   /*
       3


### PR DESCRIPTION
## Description

This PR fixes a minor bug in `disjoint_2q_block` Layering, where it previously pushed 2q-gates erroneously to the second layer, if the first layer has 1q-gates already applied to the same qubits. 

I also took this as an opportunity to separate `disjoint_2q_block` and `disjoint_qubits` into 2 different functions for the sake of readability. It was already getting cluttered now, and with a soon-to-come suggestion for another similar layering technique (specifically designed for noise-aware mapping) the problem will probably only get worse. 
In my opinion, the ensuing code duplication is not too bad, but if you disagree, I am also happy to reintegrate both functions back into one.

Additionally, I added the mapping option `add_barriers_between_layers` intended for making layer boundaries visible after the mapping process.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
