### PR TITLE
Fixing bug in single-qubit gate adjusting in `HeuristicMapper`

### DIFF
--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -508,7 +508,7 @@ void HeuristicMapper::routeCircuit() {
           locations.at(target) = static_cast<std::int16_t>(loc);
           qubits.at(loc)       = static_cast<std::int16_t>(target);
           op->setTargets({static_cast<qc::Qubit>(loc)});
-          qcMapped.initialLayout.at(target)                       = loc;
+          qcMapped.initialLayout.at(loc)                          = target;
           qcMapped.outputPermutation[static_cast<qc::Qubit>(loc)] = target;
           qcMapped.garbage.at(loc)                                = false;
         } else {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -752,70 +752,47 @@ TEST(Functionality, InitialLayoutDump) {
   qc.cx(12, 10);
   qc.cx(3, 5);
   qc.cx(8, 7);
-  
+
   // subgraph of IBM's Brisbane Backend
-  Architecture    arch{27U, {
-    {1, 0},
-    {2, 1},
-    {3, 2},
-    {4, 3},
-    {4, 5},
-    {4, 15},
-    {6, 5},
-    {6, 7},
-    {7, 8},
-    {8, 9},
-    {10, 9},
-    {10, 11},
-    {11, 12},
-    {12, 17},
-    {13, 12},
-    {14, 0},
-    {14, 18},
-    {15, 22},
-    {16, 8},
-    {16, 26},
-    {18, 19},
-    {20, 19},
-    {21, 20},
-    {21, 22},
-    {22, 23},
-    {24, 23},
-    {25, 24},
-    {26, 25}
-  }};
-  
+  Architecture arch{27U,
+                    {{1, 0},   {2, 1},   {3, 2},   {4, 3},   {4, 5},   {4, 15},
+                     {6, 5},   {6, 7},   {7, 8},   {8, 9},   {10, 9},  {10, 11},
+                     {11, 12}, {12, 17}, {13, 12}, {14, 0},  {14, 18}, {15, 22},
+                     {16, 8},  {16, 26}, {18, 19}, {20, 19}, {21, 20}, {21, 22},
+                     {22, 23}, {24, 23}, {25, 24}, {26, 25}}};
+
   Configuration config{};
-  config.method = Method::Heuristic;
+  config.method   = Method::Heuristic;
   config.layering = Layering::Disjoint2qBlocks;
-  
+
   HeuristicMapper mapper(qc, arch);
   mapper.map(config);
-  
+
   std::stringstream qasmStream{};
   mapper.dumpResult(qasmStream, qc::Format::OpenQASM);
   const std::string qasm = qasmStream.str();
-  
-  qasmStream = std::stringstream(qasm);
+
+  qasmStream    = std::stringstream(qasm);
   auto qcMapped = qc::QuantumComputation();
   qcMapped.import(qasmStream, qc::Format::OpenQASM);
-  
+
   qasmStream = std::stringstream(qasm);
   std::string line;
-  bool foundPermutation = false;
+  bool        foundPermutation = false;
   while (std::getline(qasmStream, line)) {
     if (line.rfind("// i ", 0) == 0) {
-      std::stringstream lineStream(line.substr(5));
-      std::string       entry;
+      std::stringstream          lineStream(line.substr(5));
+      std::string                entry;
       std::vector<std::uint32_t> qubits{};
       while (std::getline(lineStream, entry, ' ')) {
-        EXPECT_NO_THROW(qubits.push_back(std::stoi(entry))) << "invalid qubit id " << entry;
+        EXPECT_NO_THROW(qubits.push_back(std::stoi(entry)))
+            << "invalid qubit id " << entry;
       }
       std::set<std::uint32_t> qubitSet(qubits.begin(), qubits.end());
       EXPECT_EQ(qubitSet.size(), qubits.size());
       for (std::uint32_t i = 0; i < qcMapped.getNqubits(); ++i) {
-        EXPECT_TRUE(qubitSet.count(i) > 0) << "qubit " << std::to_string(i) <<
-                                               " not found in layout";
+        EXPECT_TRUE(qubitSet.count(i) > 0)
+            << "qubit " << std::to_string(i) << " not found in layout";
       }
       foundPermutation = true;
       break;

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -785,7 +785,8 @@ TEST(Functionality, InitialLayoutDump) {
       std::string                entry;
       std::vector<std::uint32_t> qubits{};
       while (std::getline(lineStream, entry, ' ')) {
-        EXPECT_NO_THROW(qubits.emplace_back(static_cast<std::uint32_t>(std::stoul(entry))))
+        EXPECT_NO_THROW(
+            qubits.emplace_back(static_cast<std::uint32_t>(std::stoul(entry))))
             << "invalid qubit id " << entry;
       }
       const std::set<std::uint32_t> qubitSet(qubits.begin(), qubits.end());

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -785,10 +785,10 @@ TEST(Functionality, InitialLayoutDump) {
       std::string                entry;
       std::vector<std::uint32_t> qubits{};
       while (std::getline(lineStream, entry, ' ')) {
-        EXPECT_NO_THROW(qubits.push_back(std::stoi(entry)))
+        EXPECT_NO_THROW(qubits.emplace_back(static_cast<std::uint32_t>(std::stoul(entry))))
             << "invalid qubit id " << entry;
       }
-      std::set<std::uint32_t> qubitSet(qubits.begin(), qubits.end());
+      const std::set<std::uint32_t> qubitSet(qubits.begin(), qubits.end());
       EXPECT_EQ(qubitSet.size(), qubits.size());
       for (std::uint32_t i = 0; i < qcMapped.getNqubits(); ++i) {
         EXPECT_TRUE(qubitSet.count(i) > 0)


### PR DESCRIPTION
## Description

The changed line previously treated `qc::QuantumComputation::initialLayout` as a mapping from virtual qubits to physical qubits instead of the other way around, which seems to be the canonical way everywhere else in the project. This leads to invalid qubit layouts in some edge cases (i.e. non-bijective mappings)

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
