### PR TITLE
Fix `generatedNodes` benchmark bug

### DIFF
--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -672,8 +672,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
     const std::chrono::duration<double> diff = end - start;
     results.heuristicBenchmark.secondsPerNode += diff.count();
 
-    layerResultsIt->generatedNodes =
-        layerResultsIt->expandedNodes + nodes.size();
+    layerResultsIt->generatedNodes = nextNodeId;
     results.heuristicBenchmark.generatedNodes += layerResultsIt->generatedNodes;
 
     if (layerResultsIt->expandedNodes > 0) {

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -165,6 +165,34 @@ TEST(Functionality, EmptyDump) {
   EXPECT_THROW(mapper.dumpResult("test.dummy"), QMAPException);
 }
 
+TEST(Functionality, BenchmarkGeneratedNodes) {
+  qc::QuantumComputation qc{16, 16};
+  qc.cx(qc::Control{0}, 6);
+  for (std::size_t i = 0; i < 16; ++i) {
+    qc.measure(static_cast<qc::Qubit>(i), i);
+  }
+  Architecture ibmQX5{};
+  ibmQX5.loadCouplingMap(AvailableArchitecture::IbmQx5);
+  auto ibmQX5Mapper = std::make_unique<HeuristicMapper>(qc, ibmQX5);
+  
+  Configuration settings{};
+  settings.admissibleHeuristic = true;
+  settings.lookahead = false;
+  settings.layering = Layering::IndividualGates;
+  settings.automaticLayerSplits = false;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.preMappingOptimizations = false;
+  settings.postMappingOptimizations = false;
+  settings.considerFidelity = false;
+  settings.useTeleportation = false;
+  settings.debug = true;
+  ibmQX5Mapper->map(settings);
+  auto results = ibmQX5Mapper->getResults();
+  
+  EXPECT_EQ(results.heuristicBenchmark.generatedNodes, 30);
+  EXPECT_EQ(results.layerHeuristicBenchmark.at(0).generatedNodes, 30);
+}
+
 TEST(Functionality, InvalidSettings) {
   qc::QuantumComputation qc{1};
   qc.x(0);

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -174,21 +174,21 @@ TEST(Functionality, BenchmarkGeneratedNodes) {
   Architecture ibmQX5{};
   ibmQX5.loadCouplingMap(AvailableArchitecture::IbmQx5);
   auto ibmQX5Mapper = std::make_unique<HeuristicMapper>(qc, ibmQX5);
-  
+
   Configuration settings{};
-  settings.admissibleHeuristic = true;
-  settings.lookahead = false;
-  settings.layering = Layering::IndividualGates;
-  settings.automaticLayerSplits = false;
-  settings.initialLayout = InitialLayout::Identity;
-  settings.preMappingOptimizations = false;
+  settings.admissibleHeuristic      = true;
+  settings.lookahead                = false;
+  settings.layering                 = Layering::IndividualGates;
+  settings.automaticLayerSplits     = false;
+  settings.initialLayout            = InitialLayout::Identity;
+  settings.preMappingOptimizations  = false;
   settings.postMappingOptimizations = false;
-  settings.considerFidelity = false;
-  settings.useTeleportation = false;
-  settings.debug = true;
+  settings.considerFidelity         = false;
+  settings.useTeleportation         = false;
+  settings.debug                    = true;
   ibmQX5Mapper->map(settings);
   auto results = ibmQX5Mapper->getResults();
-  
+
   EXPECT_EQ(results.heuristicBenchmark.generatedNodes, 30);
   EXPECT_EQ(results.layerHeuristicBenchmark.at(0).generatedNodes, 30);
 }


### PR DESCRIPTION
## Description

Fixing a minor bug, where sometimes the number of generated nodes is undercounted in the benchmark because nodes with equivalent layout are not added multiple times to the priority queue. Therefore, instead of relying on the size of the priority queue, it is more stable to rely on the node ids, which are strictly incremented for each generated node.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
