### PR TITLE
Fixing bug with `show_layout=None` in `SearchVisualizer`

### DIFF
--- a/src/mqt/qmap/visualization/visualize_search_graph.py
+++ b/src/mqt/qmap/visualization/visualize_search_graph.py
@@ -2040,7 +2040,8 @@ def visualize_search_graph(
                 )
 
         current_node_layout_visualized = None
-        visualize_search_node_layout(None, [0], None)
+        if not hide_layout:
+            visualize_search_node_layout(None, [0], None)
         cl = current_layer
         current_layer = None  # to prevent triggering redraw in update_timestep
         timestep_play.max = len(search_graph.nodes)


### PR DESCRIPTION
## Description

Fixing a bug, where in some cases passing `show_layout=None` to `SearchVisualizer` (i.e. hiding the architecture/layout graph), will call the architecture visualization procedure without valid architecture node positions resulting in an exception being raised.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
