### PR TITLE
SearchVisualizer: New feature `show_only_solution_path` and fixing `tapered_search_layer_heights`

### DIFF
--- a/src/mqt/qmap/visualization/search_visualizer.py
+++ b/src/mqt/qmap/visualization/search_visualizer.py
@@ -76,6 +76,7 @@ class SearchVisualizer:
         show_layout: Literal["hover", "click"] | None = "hover",
         show_swaps: bool = True,
         show_shared_swaps: bool = True,
+        show_only_solution_path: bool = False,
         color_valid_mapping: str | None = "green",
         color_final_node: str | None = "red",
         search_node_color: str
@@ -119,6 +120,7 @@ class SearchVisualizer:
             show_layout (Literal['hover', 'click'] | None): If the current qubit layout should be shown on the qubit connectivity graph, when clicking or hovering on a search node or not at all. Defaults to "hover".
             show_swaps (bool): Showing swaps on the connectivity graph. Defaults to True.
             show_shared_swaps (bool): Indicate a shared swap by 1 arrow with 2 heads, otherwise 2 arrows in opposite direction are drawn for the 1 shared swap. Defaults to True.
+            show_only_solution_path (bool): If only the final solution path should be shown. Defaults to False.
             color_valid_mapping (str | None): Color to use for search nodes containing a valid qubit layout (in CSS format). Defaults to "green".
             color_final_node (str | None): Color to use for the final solution search node (in CSS format). Defaults to "red".
             search_node_color (str | Callable[[SearchNode], float] | list[str | Callable[[SearchNode], float]]): Color to be used for search nodes. Either a static color (in CSS format) or function mapping a mqt.qmap.visualization.SearchNode to a float value, which in turn gets translated into a color by ``search_node_color_scale`` , or a preset data feature ('total_cost' | 'fixed_cost' | 'heuristic_cost' | 'lookahead_penalty'). In case a 3D search graph is used with multiple points per search node, each point's color can be controlled individually via a list. Defaults to "total_cost".
@@ -187,6 +189,7 @@ class SearchVisualizer:
             show_layout=show_layout,
             show_swaps=show_swaps,
             show_shared_swaps=show_shared_swaps,
+            show_only_solution_path=show_only_solution_path,
             color_valid_mapping=color_valid_mapping,
             color_final_node=color_final_node,
             search_node_color=search_node_color,

--- a/src/mqt/qmap/visualization/visualize_search_graph.py
+++ b/src/mqt/qmap/visualization/visualize_search_graph.py
@@ -99,6 +99,8 @@ def _remove_first_lines(string: str, n: int) -> str:
 
 def _get_avg_min_distance(seq: Iterable[float | int]) -> float:
     arr = sorted(seq)
+    if len(arr) < 2:
+        return 0.0
     sum_dist = 0.0
     for i in range(1, len(arr)):
         sum_dist += float(arr[i] - arr[i - 1])
@@ -129,36 +131,56 @@ def _copy_to_dict(
 class RootNodeNotFoundError(Exception):
     """Raised when the root node of a search graph could not be found."""
 
+class FinalNodeNotFoundError(Exception):
+    """Raised when the final solution node of a search graph could not be found."""
 
-def _parse_search_graph(file_path: str, final_node_id: int) -> tuple[nx.Graph, int]:
+
+def _parse_search_graph(file_path: str, final_node_id: int, only_solution_path: bool) -> tuple[nx.Graph, int]:
     graph = nx.Graph()
-    root = None
+    root: None | int = None
+    nodes: dict[int, SearchNode] = {}
     with Path(file_path).open() as file:
         for linestr in file:
             line = linestr.strip().split(";")
-            node = int(line[0])
-            parent = int(line[1])
-            data = SearchNode(
-                node,
-                parent if parent != node else None,
+            nodeid = int(line[0])
+            parentid = int(line[1])
+            nodes[nodeid] = SearchNode(
+                nodeid,
+                parentid if parentid != nodeid else None,
                 float(line[2]),
                 float(line[3]),
                 float(line[4]),
                 line[5].strip() == "1",
-                node == final_node_id,
+                nodeid == final_node_id,
                 int(line[6]),
                 tuple(int(q) for q in line[7].strip().split(",")),
                 ()
                 if len(line[8].strip()) == 0
                 else tuple((int(swap.split(" ")[0]), int(swap.split(" ")[1])) for swap in line[8].strip().split(",")),
             )
-            graph.add_node(node, data=data)
-            if parent == node:
-                root = node
-            else:
-                graph.add_edge(node, parent)
+            if parentid == nodeid:
+                root = nodeid
     if root is None:
         raise RootNodeNotFoundError
+    if only_solution_path:
+        if final_node_id not in nodes:
+            raise FinalNodeNotFoundError
+        path: list[SearchNode] = []
+        curr_node = nodes[final_node_id]
+        while curr_node is not None:
+            path.append(curr_node)
+            if curr_node.parent is None:
+                break
+            curr_node = nodes[curr_node.parent]
+        for node in path:
+            graph.add_node(node.nodeid, data=node)
+            if node.nodeid != root:
+                graph.add_edge(node.nodeid, node.parent)
+    else:
+        for _, node in nodes.items():
+            graph.add_node(node.nodeid, data=node)
+            if node.nodeid != root:
+                graph.add_edge(node.nodeid, node.parent)
     return graph, root
 
 
@@ -183,9 +205,10 @@ def _layout_search_graph(
     for n in pos:
         x, y = pos[n]
         if y not in layers_x:
-            layers_x[y] = [x]
+            layers_x[y] = []
         layers_x[y].append(x)
-    if len(layers_x) <= len(search_graph.nodes):
+    # for simple/degenerate trees no tapering needed
+    if len(layers_x) >= len(search_graph.nodes):
         return pos
 
     avg_spacing = 0.0
@@ -756,6 +779,7 @@ def _load_layer_data(
     color_final_node: str | None,
     draw_stems: bool,
     draw_edges: bool,
+    show_only_solution_path: bool,
 ) -> tuple[
     nx.Graph,  # search_graph
     list[int],  # initial_layout
@@ -802,7 +826,7 @@ def _load_layer_data(
     initial_positions = _reverse_layout(initial_layout)
     final_node_id = circuit_layer["final_node_id"]
 
-    graph, graph_root = _parse_search_graph(f"{data_logging_path}nodes_layer_{layer}.csv", final_node_id)
+    graph, graph_root = _parse_search_graph(f"{data_logging_path}nodes_layer_{layer}.csv", final_node_id, show_only_solution_path)
 
     pos = _layout_search_graph(graph, graph_root, layout, tapered_layer_heights)
 
@@ -1000,6 +1024,7 @@ def _visualize_search_graph_check_parameters(
     show_layout: Literal["hover", "click"] | None,
     show_swaps: bool,
     show_shared_swaps: bool,
+    show_only_solution_path: bool,
     color_valid_mapping: str | None,
     color_final_node: str | None,
     search_node_color: str | (Callable[[SearchNode], float] | Sequence[str | Callable[[SearchNode], float]]),
@@ -1148,6 +1173,10 @@ def _visualize_search_graph_check_parameters(
 
     if not isinstance(show_shared_swaps, bool):
         msg = "show_shared_swaps must be a boolean"  # type: ignore[unreachable]
+        raise TypeError(msg)
+    
+    if not isinstance(show_only_solution_path, bool):
+        msg = "show_only_solution_path must be a boolean"  # type: ignore[unreachable]
         raise TypeError(msg)
 
     if (
@@ -1507,6 +1536,7 @@ def visualize_search_graph(
     show_layout: Literal["hover", "click"] | None = "hover",
     show_swaps: bool = True,
     show_shared_swaps: bool = True,
+    show_only_solution_path: bool = False,
     color_valid_mapping: str | None = "green",
     color_final_node: str | None = "red",
     search_node_color: str
@@ -1551,6 +1581,7 @@ def visualize_search_graph(
         show_layout (Literal['hover', 'click'] | None): If the current qubit layout should be shown on the qubit connectivity graph, when clicking or hovering on a search node or not at all. Defaults to "hover".
         show_swaps (bool): Showing swaps on the connectivity graph. Defaults to True.
         show_shared_swaps (bool): Indicate a shared swap by 1 arrow with 2 heads, otherwise 2 arrows in opposite direction are drawn for the 1 shared swap. Defaults to True.
+        show_only_solution_path (bool): If only the final solution path should be shown. Defaults to False.
         color_valid_mapping (str | None): Color to use for search nodes containing a valid qubit layout (in CSS format). Defaults to "green".
         color_final_node (str | None): Color to use for the final solution search node (in CSS format). Defaults to "red".
         search_node_color (str | Callable[[SearchNode], float] | Sequence[str | Callable[[SearchNode], float]]): Color to be used for search nodes. Either a static color (in CSS format) or function mapping a mqt.qmap.visualization.SearchNode to a float value, which in turn gets translated into a color by `search_node_color_scale`, or a preset data feature ('total_cost' | 'fixed_cost' | 'heuristic_cost' | 'lookahead_penalty'). In case a 3D search graph is used with multiple points per search node, each point's color can be controlled individually via a list. Defaults to "total_cost".
@@ -1631,6 +1662,7 @@ def visualize_search_graph(
         show_layout,
         show_swaps,
         show_shared_swaps,
+        show_only_solution_path,
         color_valid_mapping,
         color_final_node,
         search_node_color,
@@ -1978,6 +2010,7 @@ def visualize_search_graph(
                 color_final_node,
                 draw_stems,
                 draw_search_edges,
+                show_only_solution_path
             )
         search_graph = search_graphs[current_layer]
         initial_layout = initial_layouts[current_layer]

--- a/src/mqt/qmap/visualization/visualize_search_graph.py
+++ b/src/mqt/qmap/visualization/visualize_search_graph.py
@@ -131,6 +131,7 @@ def _copy_to_dict(
 class RootNodeNotFoundError(Exception):
     """Raised when the root node of a search graph could not be found."""
 
+
 class FinalNodeNotFoundError(Exception):
     """Raised when the final solution node of a search graph could not be found."""
 
@@ -177,7 +178,7 @@ def _parse_search_graph(file_path: str, final_node_id: int, only_solution_path: 
             if node.nodeid != root:
                 graph.add_edge(node.nodeid, node.parent)
     else:
-        for _, node in nodes.items():
+        for node in nodes.values():
             graph.add_node(node.nodeid, data=node)
             if node.nodeid != root:
                 graph.add_edge(node.nodeid, node.parent)
@@ -826,7 +827,9 @@ def _load_layer_data(
     initial_positions = _reverse_layout(initial_layout)
     final_node_id = circuit_layer["final_node_id"]
 
-    graph, graph_root = _parse_search_graph(f"{data_logging_path}nodes_layer_{layer}.csv", final_node_id, show_only_solution_path)
+    graph, graph_root = _parse_search_graph(
+        f"{data_logging_path}nodes_layer_{layer}.csv", final_node_id, show_only_solution_path
+    )
 
     pos = _layout_search_graph(graph, graph_root, layout, tapered_layer_heights)
 
@@ -1174,7 +1177,7 @@ def _visualize_search_graph_check_parameters(
     if not isinstance(show_shared_swaps, bool):
         msg = "show_shared_swaps must be a boolean"  # type: ignore[unreachable]
         raise TypeError(msg)
-    
+
     if not isinstance(show_only_solution_path, bool):
         msg = "show_only_solution_path must be a boolean"  # type: ignore[unreachable]
         raise TypeError(msg)
@@ -2010,7 +2013,7 @@ def visualize_search_graph(
                 color_final_node,
                 draw_stems,
                 draw_search_edges,
-                show_only_solution_path
+                show_only_solution_path,
             )
         search_graph = search_graphs[current_layer]
         initial_layout = initial_layouts[current_layer]

--- a/src/mqt/qmap/visualization/visualize_search_graph.py
+++ b/src/mqt/qmap/visualization/visualize_search_graph.py
@@ -201,8 +201,7 @@ def _layout_search_graph(
     if not tapered_layer_heights:
         return pos
 
-    layers_x = {}
-    layer_spacings = {}
+    layers_x: dict[float, list[float]] = {}
     for n in pos:
         x, y = pos[n]
         if y not in layers_x:
@@ -212,11 +211,12 @@ def _layout_search_graph(
     if len(layers_x) >= len(search_graph.nodes):
         return pos
 
+    layer_spacings: dict[float, float] = {}
     avg_spacing = 0.0
     for y in layers_x:
         layer_spacings[y] = _get_avg_min_distance(layers_x[y])
         avg_spacing += layer_spacings[y]
-    avg_spacing /= len(layers_x)
+    avg_spacing /= float(len(layers_x))
     layer_spacings_items = sorted(layer_spacings.items(), key=lambda x: x[0])
     for i in range(len(layer_spacings_items)):
         before = layer_spacings_items[i - 1][1] if i != 0 else 0


### PR DESCRIPTION
## Description

- Adding a new option to the search graph visualizer to only show the final solution path in each layer (intended for large, convoluted search trees and situations where only the final solution is of interest)
- Fixing a minor bug that rendered the option `tapered_search_layer_heights` ineffective in many cases

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
