### PR TITLE
🩹 fix test file configuration

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,9 +8,9 @@ if(TARGET MQT::QMapExact)
 endif()
 
 if(TARGET MQT::QMapCliffordSynthesis)
-  configure_file(${CMAKE_SOURCE_DIR}/test/cliffordsynthesis/tableaus.json
+  configure_file(${PROJECT_SOURCE_DIR}/test/cliffordsynthesis/tableaus.json
                  ${CMAKE_CURRENT_BINARY_DIR}/cliffordsynthesis/tableaus.json COPYONLY)
-  configure_file(${CMAKE_SOURCE_DIR}/test/cliffordsynthesis/circuits.json
+  configure_file(${PROJECT_SOURCE_DIR}/test/cliffordsynthesis/circuits.json
                  ${CMAKE_CURRENT_BINARY_DIR}/cliffordsynthesis/circuits.json COPYONLY)
   package_add_test(
     mqt-qmap-cliffordsynthesis-test MQT::QMapCliffordSynthesis


### PR DESCRIPTION
## Description

This fixes a small mistake in the CMake configuration that would prevent the usage of mqt-qmap as a submodule.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
