### PR TITLE
✨ Support for Qiskit 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "qiskit[qasm3-import]>=1.0.0",
-    "rustworkx[all]>=0.13.0",
+    "rustworkx[all]>=0.14.0",
     "importlib_resources>=5.0; python_version < '3.10'",
     "typing_extensions>=4.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "qiskit[qasm3-import]>=0.46.0",
+    "qiskit[qasm3-import]>=1.0.0",
     "rustworkx[all]>=0.13.0",
     "importlib_resources>=5.0; python_version < '3.10'",
     "typing_extensions>=4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "qiskit[qasm3-import]>=1.0.0",
     "rustworkx[all]>=0.14.0",
     "importlib_resources>=5.0; python_version < '3.10'",
-    "typing_extensions>=4.0"
+    "typing_extensions>=4.2"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest>=7", "mqt.qcec>=2", "mqt.qmap[visualization]"]
+test = ["pytest>=7", "mqt.qcec>=2.4.5", "mqt.qmap[visualization]"]
 coverage = ["mqt.qmap[test]", "pytest-cov"]
 docs = [
     "furo>=2023.08.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,14 +141,7 @@ log_cli_level = "INFO"
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore:Conversion.*to a scalar is deprecated.*:DeprecationWarning:qiskit:",
-    "ignore:.*qiskit.__qiskit_version__.*:DeprecationWarning:qiskit:",
-    "ignore:.*qiskit.utils.algorithm_globals.QiskitAlgorithmGlobals*:DeprecationWarning:qiskit",
-    "ignore:.*qiskit.extensions module is pending deprecation*:PendingDeprecationWarning:qiskit",
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
-    'ignore:.*qiskit.utils.parallel*:DeprecationWarning:qiskit',
-    'ignore:.*qiskit.tools.events*:DeprecationWarning:qiskit',
-    'ignore:.*qiskit.qasm*:DeprecationWarning:qiskit',
 ]
 
 [tool.coverage]

--- a/src/mqt/qmap/load_calibration.py
+++ b/src/mqt/qmap/load_calibration.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qiskit.providers.models import BackendProperties
 from qiskit.transpiler.target import Target
 
 if TYPE_CHECKING:
     from .pyqmap import Architecture
 
 
-def load_calibration(architecture: Architecture, calibration: str | Target | None = None) -> None:
+def load_calibration(architecture: Architecture, calibration: str | Target | BackendProperties | None = None) -> None:
     """Load a calibration from a string, BackendProperties, or Target.
 
     Args:
@@ -22,6 +23,10 @@ def load_calibration(architecture: Architecture, calibration: str | Target | Non
 
     if isinstance(calibration, str):
         architecture.load_properties(calibration)
+    elif isinstance(calibration, BackendProperties):
+        from mqt.qmap.qiskit.backend import import_backend_properties
+
+        architecture.load_properties(import_backend_properties(calibration))
     elif isinstance(calibration, Target):
         from mqt.qmap.qiskit.backend import import_target
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,3 +1,12 @@
+if(APPLE)
+  set(BASEPOINT @loader_path)
+else()
+  set(BASEPOINT $ORIGIN)
+endif()
+list(APPEND CMAKE_INSTALL_RPATH ${BASEPOINT} ${BASEPOINT}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
 pybind11_add_module(
   pyqmap
   # Prefer thin LTO if available

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -6,7 +6,7 @@ importlib_resources==5.0.0
 typing_extensions==4.0.0
 qiskit==1.0.0
 rustworkx==0.14.0
-mqt.qcec==2.0.0
+mqt.qcec==2.4.5
 distinctipy==1.2.2
 plotly==5.15.0
 networkx==2.5

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -5,7 +5,7 @@ pytest==7.0.0
 importlib_resources==5.0.0
 typing_extensions==4.0.0
 qiskit==1.0.0
-rustworkx==0.13.0
+rustworkx==0.14.0
 mqt.qcec==2.0.0
 distinctipy==1.2.2
 plotly==5.15.0

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -3,7 +3,7 @@ setuptools-scm==7.0.0
 pybind11==2.11.0
 pytest==7.0.0
 importlib_resources==5.0.0
-typing_extensions==4.0.0
+typing_extensions==4.2.0
 qiskit==1.0.0
 rustworkx==0.14.0
 mqt.qcec==2.4.5

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -4,7 +4,7 @@ pybind11==2.11.0
 pytest==7.0.0
 importlib_resources==5.0.0
 typing_extensions==4.0.0
-qiskit==0.46.0
+qiskit==1.0.0
 rustworkx==0.13.0
 mqt.qcec==2.0.0
 distinctipy==1.2.2

--- a/test/python/test.py
+++ b/test/python/test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from qiskit import QuantumCircuit
-from qiskit.providers.fake_provider import FakeLondon
+from qiskit.providers.fake_provider import Fake5QV1
 
 from mqt import qmap
 
@@ -16,5 +16,5 @@ if __name__ == "__main__":
     print(qc.draw(fold=-1))
 
     # compile the circuit
-    qc_mapped, results = qmap.compile(qc, arch=FakeLondon())
+    qc_mapped, results = qmap.compile(qc, arch=Fake5QV1())
     print(qc_mapped.draw(fold=-1))

--- a/test/python/test_qiskit_backend_imports.py
+++ b/test/python/test_qiskit_backend_imports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from qiskit import QuantumCircuit
-from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit.providers.fake_provider import Fake5QV1, GenericBackendV2
 
 from mqt import qmap
 
@@ -24,6 +24,20 @@ def example_circuit() -> QuantumCircuit:
 def backend() -> GenericBackendV2:
     """Return a test backend."""
     return GenericBackendV2(num_qubits=5, coupling_map=[[0, 1], [1, 0], [1, 2], [2, 1], [1, 3], [3, 1], [3, 4], [4, 3]])
+
+
+def test_backend_v1(example_circuit: QuantumCircuit) -> None:
+    """Test that circuits can be mapped to Qiskit BackendV1 instances providing the new basis_gates."""
+    _, results = qmap.compile(example_circuit, arch=Fake5QV1())
+    assert results.timeout is False
+    assert results.mapped_circuit
+
+
+def test_architecture_from_v1_backend_properties(example_circuit: QuantumCircuit) -> None:
+    """Test that circuits can be mapped by simply providing the backend properties (the BackendV1 way)."""
+    _, results = qmap.compile(example_circuit, arch=None, calibration=Fake5QV1().properties())
+    assert results.timeout is False
+    assert results.mapped_circuit
 
 
 def test_backend_v2(example_circuit: QuantumCircuit, backend: GenericBackendV2) -> None:


### PR DESCRIPTION
## Description

This PR marks the official support of Qiskit 1.0 in mqt-qmap.

In order to avoid all kinds of ugly compatibility hacks, this PR also changes the minimum required Qiskit version to 1.0.
Since Qiskit has devoted themselves to following semantic versioning from now on out, this hopefully means fewer compatibility changes in the future.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
