### PR TITLE
🚨 Fix new warnings revealed by clang-tidy 18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,3 @@
 BasedOnStyle: LLVM
-AlignConsecutiveAssignments: Consecutive
-AlignConsecutiveDeclarations: Consecutive
 IncludeBlocks: Regroup
-KeepEmptyLinesAtTheStartOfBlocks: false
 PointerAlignment: Left
-SpacesInContainerLiterals: false

--- a/cmake/try_z3.cpp
+++ b/cmake/try_z3.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <z3.h>
+#include <z3_api.h> // IWYU pragma: keep
 
 int main() {
   std::cout << Z3_get_full_version();

--- a/include/Architecture.hpp
+++ b/include/Architecture.hpp
@@ -22,14 +22,14 @@
 #include <utility>
 #include <vector>
 
-constexpr std::uint8_t GATES_OF_BIDIRECTIONAL_SWAP  = 3U;
+constexpr std::uint8_t GATES_OF_BIDIRECTIONAL_SWAP = 3U;
 constexpr std::uint8_t GATES_OF_UNIDIRECTIONAL_SWAP = 7U;
-constexpr std::uint8_t GATES_OF_DIRECTION_REVERSE   = 4U;
-constexpr std::uint8_t GATES_OF_TELEPORTATION       = 7U;
+constexpr std::uint8_t GATES_OF_DIRECTION_REVERSE = 4U;
+constexpr std::uint8_t GATES_OF_TELEPORTATION = 7U;
 
 constexpr std::uint32_t COST_SINGLE_QUBIT_GATE = 1;
-constexpr std::uint32_t COST_CNOT_GATE         = 10;
-constexpr std::uint32_t COST_MEASUREMENT       = 10;
+constexpr std::uint32_t COST_CNOT_GATE = 10;
+constexpr std::uint32_t COST_MEASUREMENT = 10;
 constexpr std::uint32_t COST_UNIDIRECTIONAL_SWAP =
     3 * COST_CNOT_GATE + 4 * COST_SINGLE_QUBIT_GATE;
 constexpr std::uint32_t COST_BIDIRECTIONAL_SWAP = 3 * COST_CNOT_GATE;
@@ -47,7 +47,7 @@ public:
     public:
       Property() = default;
 
-      [[nodiscard]] auto&       get(const KeyType& key) { return props[key]; }
+      [[nodiscard]] auto& get(const KeyType& key) { return props[key]; }
       [[nodiscard]] const auto& get(const KeyType& key) const {
         return props.at(key);
       }
@@ -58,7 +58,7 @@ public:
       [[nodiscard, gnu::pure]] bool available(const KeyType& key) const {
         return props.find(key) != props.end();
       }
-      void               clear() { props.clear(); }
+      void clear() { props.clear(); }
       [[nodiscard]] bool empty() const { return props.empty(); }
 
     protected:
@@ -72,27 +72,27 @@ public:
     void setName(const std::string& propertiesName) { name = propertiesName; }
 
     [[nodiscard]] std::uint16_t getNqubits() const { return nq; }
-    void                        setNqubits(std::uint16_t nqs) { nq = nqs; }
+    void setNqubits(std::uint16_t nqs) { nq = nqs; }
 
     Property<std::uint16_t, Property<qc::OpType, double>> singleQubitErrorRate;
     Property<std::uint16_t,
              Property<std::uint16_t, Property<qc::OpType, double>>>
-                                         twoQubitErrorRate;
-    Property<std::uint16_t, double>      readoutErrorRate;
-    Property<std::uint16_t, double>      t1Time;
-    Property<std::uint16_t, double>      t2Time;
-    Property<std::uint16_t, double>      qubitFrequency;
+        twoQubitErrorRate;
+    Property<std::uint16_t, double> readoutErrorRate;
+    Property<std::uint16_t, double> t1Time;
+    Property<std::uint16_t, double> t2Time;
+    Property<std::uint16_t, double> qubitFrequency;
     Property<std::uint16_t, std::string> calibrationDate;
 
     // convenience functions
-    void setSingleQubitErrorRate(std::uint16_t      qubit,
+    void setSingleQubitErrorRate(std::uint16_t qubit,
                                  const std::string& operation,
-                                 double             errorRate) {
+                                 double errorRate) {
       singleQubitErrorRate.get(qubit).set(qc::opTypeFromString(operation),
                                           errorRate);
     }
     [[nodiscard]] double
-    getSingleQubitErrorRate(std::uint16_t      qubit,
+    getSingleQubitErrorRate(std::uint16_t qubit,
                             const std::string& operation) const {
       return singleQubitErrorRate.get(qubit).get(
           qc::opTypeFromString(operation));
@@ -109,7 +109,7 @@ public:
     }
 
     void setTwoQubitErrorRate(std::uint16_t qubit1, std::uint16_t qubit2,
-                              double             errorRate,
+                              double errorRate,
                               const std::string& operation = "cx") {
       twoQubitErrorRate.get(qubit1).get(qubit2).set(
           qc::opTypeFromString(operation), errorRate);
@@ -151,7 +151,7 @@ public:
         return json;
       }
 
-      json["name"]   = name;
+      json["name"] = name;
       json["qubits"] = {};
       for (std::uint16_t i = 0U; i < nq; ++i) {
         auto& qubitProperties = json["qubits"][std::to_string(i)];
@@ -200,7 +200,7 @@ public:
     [[nodiscard]] std::string toString() const { return json().dump(2); }
 
   protected:
-    std::string   name;
+    std::string name;
     std::uint16_t nq{};
   };
 
@@ -226,7 +226,7 @@ public:
                const Properties& props);
 
   [[nodiscard]] std::uint16_t getNqubits() const { return nqubits; }
-  void                        setNqubits(std::uint16_t nQ) { nqubits = nQ; }
+  void setNqubits(std::uint16_t nQ) { nqubits = nQ; }
 
   [[nodiscard]] const std::string& getName() const { return name; }
   void setName(const std::string& architectureName) { name = architectureName; }
@@ -412,12 +412,12 @@ public:
   }
 
   void reset() {
-    name    = "";
+    name = "";
     nqubits = 0;
     couplingMap.clear();
     distanceTable.clear();
     distanceTableReversals.clear();
-    isBidirectional  = true;
+    isBidirectional = true;
     isUnidirectional = true;
     properties.clear();
     fidelityAvailable = false;
@@ -450,13 +450,13 @@ public:
   }
 
   std::uint64_t minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
-                                     std::int64_t                limit = -1);
-  void          minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
-                                     std::vector<Edge>&          swaps);
+                                     std::int64_t limit = -1);
+  void minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
+                            std::vector<Edge>& swaps);
 
   struct Node {
-    std::uint64_t                                    nswaps = 0U;
-    std::vector<Edge>                                swaps;
+    std::uint64_t nswaps = 0U;
+    std::vector<Edge> swaps;
     std::unordered_map<std::uint16_t, std::uint16_t> permutation;
 
     void print(std::ostream& out) {
@@ -477,17 +477,17 @@ public:
   getCouplingLimit(const std::set<std::uint16_t>& qubitChoice) const;
 
   void getHighestFidelityCouplingMap(std::uint16_t subsetSize,
-                                     CouplingMap&  reducedMap) const;
+                                     CouplingMap& reducedMap) const;
   [[nodiscard]] std::vector<QubitSubset>
-       getAllConnectedSubsets(std::uint16_t subsetSize) const;
-  void getReducedCouplingMaps(std::uint16_t             subsetSize,
+  getAllConnectedSubsets(std::uint16_t subsetSize) const;
+  void getReducedCouplingMaps(std::uint16_t subsetSize,
                               std::vector<CouplingMap>& couplingMaps) const;
   void getReducedCouplingMap(const QubitSubset& qubitChoice,
-                             CouplingMap&       reducedMap) const;
+                             CouplingMap& reducedMap) const;
   [[nodiscard]] static double
   getAverageArchitectureFidelity(const CouplingMap& cm,
                                  const QubitSubset& qubitChoice,
-                                 const Properties&  props);
+                                 const Properties& props);
 
   [[nodiscard]] static QubitSubset getQubitSet(const CouplingMap& cm);
   [[nodiscard]] static std::vector<std::uint16_t>
@@ -502,10 +502,10 @@ public:
   static void printCouplingMap(const CouplingMap& cm, std::ostream& os);
 
 protected:
-  std::string   name;
+  std::string name;
   std::uint16_t nqubits = 0;
-  CouplingMap   couplingMap;
-  CouplingMap   currentTeleportations;
+  CouplingMap couplingMap;
+  CouplingMap currentTeleportations;
 
   /** true if the coupling map contains no unidirectional edges */
   bool isBidirectional = true;
@@ -515,17 +515,17 @@ protected:
   // unidirectional, and coupling maps containing both bidirectional and
   // unidirectional edges are neither bidirectional nor unidirectional
 
-  Matrix                                             distanceTable;
-  Matrix                                             distanceTableReversals;
+  Matrix distanceTable;
+  Matrix distanceTableReversals;
   std::vector<std::pair<std::int16_t, std::int16_t>> teleportationQubits;
-  Properties                                         properties;
-  bool                                               fidelityAvailable = false;
-  Matrix                                             fidelityTable;
-  std::vector<double>                                singleQubitFidelities;
-  std::vector<double>                                singleQubitFidelityCosts;
-  Matrix                                             twoQubitFidelityCosts;
-  Matrix                                             swapFidelityCosts;
-  std::vector<Matrix>                                fidelityDistanceTables;
+  Properties properties;
+  bool fidelityAvailable = false;
+  Matrix fidelityTable;
+  std::vector<double> singleQubitFidelities;
+  std::vector<double> singleQubitFidelityCosts;
+  Matrix twoQubitFidelityCosts;
+  Matrix swapFidelityCosts;
+  std::vector<Matrix> fidelityDistanceTables;
 
   void createDistanceTable();
   void createFidelityTable();
@@ -538,10 +538,10 @@ protected:
                                   const std::set<Edge>& teleportations) const;
 
   static std::size_t findCouplingLimit(const CouplingMap& cm,
-                                       std::uint16_t      nQubits);
+                                       std::uint16_t nQubits);
   static std::size_t
-              findCouplingLimit(const CouplingMap& cm, std::uint16_t nQubits,
-                                const std::set<std::uint16_t>& qubitChoice);
+  findCouplingLimit(const CouplingMap& cm, std::uint16_t nQubits,
+                    const std::set<std::uint16_t>& qubitChoice);
   static void findCouplingLimit(
       std::uint16_t node, std::uint16_t curSum,
       const std::vector<std::unordered_set<std::uint16_t>>& connections,

--- a/include/DataLogger.hpp
+++ b/include/DataLogger.hpp
@@ -43,10 +43,10 @@ public:
       const std::vector<std::uint16_t>& singleQubitMultiplicity,
       const std::map<std::pair<std::uint16_t, std::uint16_t>,
                      std::pair<std::uint16_t, std::uint16_t>>&
-                                                         twoQubitMultiplicity,
+          twoQubitMultiplicity,
       const std::array<std::int16_t, MAX_DEVICE_QUBITS>& initialLayout,
       std::size_t finalNodeId, double finalCostFixed, double finalCostHeur,
-      double                                             finalLookaheadPenalty,
+      double finalLookaheadPenalty,
       const std::array<std::int16_t, MAX_DEVICE_QUBITS>& finalLayout,
       const std::vector<Exchange>& finalSwaps, std::size_t finalSearchDepth);
   void splitLayer();
@@ -66,14 +66,14 @@ public:
   void close();
 
 protected:
-  std::string                dataLoggingPath;
-  Architecture*              architecture;
-  std::uint16_t              nqubits;
-  qc::QuantumComputation     inputCircuit;
-  qc::RegisterNames          qregs{};
-  qc::RegisterNames          cregs{};
+  std::string dataLoggingPath;
+  Architecture* architecture;
+  std::uint16_t nqubits;
+  qc::QuantumComputation inputCircuit;
+  qc::RegisterNames qregs{};
+  qc::RegisterNames cregs{};
   std::vector<std::ofstream> searchNodesLogFiles; // 1 per layer
-  bool                       deactivated = false;
+  bool deactivated = false;
 
   void openNewLayer(std::size_t layer);
 };

--- a/include/DataLogger.hpp
+++ b/include/DataLogger.hpp
@@ -6,12 +6,20 @@
 #pragma once
 
 #include "Architecture.hpp"
-#include "Mapper.hpp"
+#include "Definitions.hpp"
 #include "MappingResults.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "utils.hpp"
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
+#include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 class DataLogger {
 public:
@@ -70,8 +78,8 @@ protected:
   Architecture* architecture;
   std::uint16_t nqubits;
   qc::QuantumComputation inputCircuit;
-  qc::RegisterNames qregs{};
-  qc::RegisterNames cregs{};
+  qc::RegisterNames qregs;
+  qc::RegisterNames cregs;
   std::vector<std::ofstream> searchNodesLogFiles; // 1 per layer
   bool deactivated = false;
 

--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -6,18 +6,26 @@
 #pragma once
 
 #include "Architecture.hpp"
+#include "Definitions.hpp"
 #include "MappingResults.hpp"
 #include "QuantumComputation.hpp"
 #include "configuration/Configuration.hpp"
+#include "operations/Operation.hpp"
+#include "utils.hpp"
 
+#include <algorithm>
 #include <array>
-#include <chrono>
-#include <fstream>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <map>
-#include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
 #include <set>
 #include <string>
+#include <utility>
+#include <vector>
 
 /**
  * number of two-qubit gates acting on pairs of logical qubits in some layer
@@ -85,36 +93,36 @@ protected:
    * Each entry in the outer vector corresponds to 1 layer, containing all its
    * gates in an inner vector
    */
-  std::vector<std::vector<Gate>> layers{};
+  std::vector<std::vector<Gate>> layers;
 
   /**
    * @brief The number of 1Q-gates acting on each logical qubit in each layer
    */
-  std::vector<SingleQubitMultiplicity> singleQubitMultiplicities{};
+  std::vector<SingleQubitMultiplicity> singleQubitMultiplicities;
 
   /**
    * @brief The number of 2Q-gates acting on each pair of logical qubits in each
    * layer
    */
-  std::vector<TwoQubitMultiplicity> twoQubitMultiplicities{};
+  std::vector<TwoQubitMultiplicity> twoQubitMultiplicities;
 
   /**
    * @brief For each layer the set of all logical qubits, which are acted on by
    * a gate in the layer
    */
-  std::vector<std::set<std::uint16_t>> activeQubits{};
+  std::vector<std::set<std::uint16_t>> activeQubits;
 
   /**
    * @brief For each layer the set of all logical qubits, which are acted on by
    * a 1Q-gate in the layer
    */
-  std::vector<std::set<std::uint16_t>> activeQubits1QGates{};
+  std::vector<std::set<std::uint16_t>> activeQubits1QGates;
 
   /**
    * @brief For each layer the set of all logical qubits, which are acted on by
    * a 2Q-gate in the layer
    */
-  std::vector<std::set<std::uint16_t>> activeQubits2QGates{};
+  std::vector<std::set<std::uint16_t>> activeQubits2QGates;
 
   /**
    * @brief containing the logical qubit currently mapped to each physical
@@ -131,7 +139,7 @@ protected:
    */
   std::array<std::int16_t, MAX_DEVICE_QUBITS> locations{};
 
-  MappingResults results{};
+  MappingResults results;
 
   /**
    * @brief Initialize the results structure with circuit names, registers in
@@ -279,7 +287,7 @@ public:
 
   virtual void dumpResult(const std::string& outputFilename) {
     if (qcMapped.empty()) {
-      std::cerr << "Mapped circuit is empty." << std::endl;
+      std::cerr << "Mapped circuit is empty.\n";
       return;
     }
 
@@ -316,7 +324,7 @@ public:
 
   virtual MappingResults& getResults() { return results; }
 
-  virtual nlohmann::json json() { return results.json(); }
+  virtual nlohmann::basic_json<> json() { return results.json(); }
 
   virtual std::string csv() { return results.csv(); }
 

--- a/include/Mapper.hpp
+++ b/include/Mapper.hpp
@@ -53,8 +53,8 @@ protected:
    * For a single-qubit operation `control` is set to `-1`
    */
   struct Gate {
-    std::int16_t  control = -1;
-    std::uint16_t target  = 0;
+    std::int16_t control = -1;
+    std::uint16_t target = 0;
 
     qc::Operation* op = nullptr;
 
@@ -236,16 +236,16 @@ protected:
    * results in `info.gates` and `info.cnots`
    */
   virtual void countGates(const qc::QuantumComputation& circuit,
-                          MappingResults::CircuitInfo&  info) {
+                          MappingResults::CircuitInfo& info) {
     countGates(circuit.cbegin(), circuit.cend(), info);
   }
   /**
    * @brief count number of elementary gates and cnots in circuit and save the
    * results in `info.gates` and `info.cnots`
    */
-  virtual void countGates(decltype(qcMapped.cbegin())      it,
+  virtual void countGates(decltype(qcMapped.cbegin()) it,
                           const decltype(qcMapped.cend())& end,
-                          MappingResults::CircuitInfo&     info);
+                          MappingResults::CircuitInfo& info);
 
   /**
    * @brief performs optimizations on the circuit before mapping
@@ -283,8 +283,8 @@ public:
       return;
     }
 
-    const std::size_t dot       = outputFilename.find_last_of('.');
-    std::string       extension = outputFilename.substr(dot + 1);
+    const std::size_t dot = outputFilename.find_last_of('.');
+    std::string extension = outputFilename.substr(dot + 1);
     std::transform(extension.begin(), extension.end(), extension.begin(),
                    [](unsigned char c) { return ::tolower(c); });
     if (extension == "real") {
@@ -298,10 +298,10 @@ public:
   }
 
   virtual void dumpResult(const std::string& outputFilename,
-                          qc::Format         format) {
+                          qc::Format format) {
     const std::size_t slash = outputFilename.find_last_of('/');
-    const std::size_t dot   = outputFilename.find_last_of('.');
-    results.output.name     = outputFilename.substr(slash + 1, dot - slash - 1);
+    const std::size_t dot = outputFilename.find_last_of('.');
+    results.output.name = outputFilename.substr(slash + 1, dot - slash - 1);
     qcMapped.dump(outputFilename, format);
   }
 

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -15,57 +15,57 @@
 struct MappingResults {
   struct CircuitInfo {
     // general info
-    std::string   name{};
-    std::uint16_t qubits           = 0;
-    std::size_t   gates            = 0;
-    std::size_t   singleQubitGates = 0;
-    std::size_t   cnots            = 0;
-    std::size_t   layers           = 0;
-    double        totalFidelity    = 1.;
+    std::string name{};
+    std::uint16_t qubits = 0;
+    std::size_t gates = 0;
+    std::size_t singleQubitGates = 0;
+    std::size_t cnots = 0;
+    std::size_t layers = 0;
+    double totalFidelity = 1.;
     // higher precision than totalFidelity because larger part of double's
     // representation space is used
     double totalLogFidelity = 0.;
 
     // info in output circuit
-    std::size_t swaps            = 0;
+    std::size_t swaps = 0;
     std::size_t directionReverse = 0;
-    std::size_t teleportations   = 0;
+    std::size_t teleportations = 0;
   };
 
   struct HeuristicBenchmarkInfo {
-    std::size_t expandedNodes            = 0;
-    std::size_t generatedNodes           = 0;
-    double      secondsPerNode           = 0.;
-    double      averageBranchingFactor   = 0.;
-    double      effectiveBranchingFactor = 0.;
+    std::size_t expandedNodes = 0;
+    std::size_t generatedNodes = 0;
+    double secondsPerNode = 0.;
+    double averageBranchingFactor = 0.;
+    double effectiveBranchingFactor = 0.;
 
     [[nodiscard]] nlohmann::json json() const {
       nlohmann::json resultJSON{};
-      resultJSON["expanded_nodes"]             = expandedNodes;
-      resultJSON["generated_nodes"]            = generatedNodes;
-      resultJSON["seconds_per_node"]           = secondsPerNode;
-      resultJSON["average_branching_factor"]   = averageBranchingFactor;
+      resultJSON["expanded_nodes"] = expandedNodes;
+      resultJSON["generated_nodes"] = generatedNodes;
+      resultJSON["seconds_per_node"] = secondsPerNode;
+      resultJSON["average_branching_factor"] = averageBranchingFactor;
       resultJSON["effective_branching_factor"] = effectiveBranchingFactor;
       return resultJSON;
     }
   };
 
   struct LayerHeuristicBenchmarkInfo {
-    std::size_t expandedNodes                     = 0;
-    std::size_t generatedNodes                    = 0;
-    std::size_t expandedNodesAfterFirstSolution   = 0;
+    std::size_t expandedNodes = 0;
+    std::size_t generatedNodes = 0;
+    std::size_t expandedNodesAfterFirstSolution = 0;
     std::size_t expandedNodesAfterOptimalSolution = 0;
-    std::size_t solutionNodes                     = 0;
+    std::size_t solutionNodes = 0;
     std::size_t solutionNodesAfterOptimalSolution = 0;
-    std::size_t solutionDepth                     = 0;
-    double      secondsPerNode                    = 0.;
-    double      averageBranchingFactor            = 0.;
-    double      effectiveBranchingFactor          = 0.;
-    bool        earlyTermination                  = false;
+    std::size_t solutionDepth = 0;
+    double secondsPerNode = 0.;
+    double averageBranchingFactor = 0.;
+    double effectiveBranchingFactor = 0.;
+    bool earlyTermination = false;
 
     [[nodiscard]] nlohmann::json json() const {
       nlohmann::json resultJSON{};
-      resultJSON["expanded_nodes"]  = expandedNodes;
+      resultJSON["expanded_nodes"] = expandedNodes;
       resultJSON["generated_nodes"] = generatedNodes;
       resultJSON["expanded_nodes_after_first_solution"] =
           expandedNodesAfterFirstSolution;
@@ -74,41 +74,41 @@ struct MappingResults {
       resultJSON["solution_nodes"] = solutionNodes;
       resultJSON["solution_nodes_after_optimal_solution"] =
           solutionNodesAfterOptimalSolution;
-      resultJSON["solution_depth"]             = solutionDepth;
-      resultJSON["seconds_per_node"]           = secondsPerNode;
-      resultJSON["average_branching_factor"]   = averageBranchingFactor;
+      resultJSON["solution_depth"] = solutionDepth;
+      resultJSON["seconds_per_node"] = secondsPerNode;
+      resultJSON["average_branching_factor"] = averageBranchingFactor;
       resultJSON["effective_branching_factor"] = effectiveBranchingFactor;
-      resultJSON["early_termination"]          = earlyTermination;
+      resultJSON["early_termination"] = earlyTermination;
       return resultJSON;
     }
   };
 
   CircuitInfo input{};
 
-  std::string   architecture{};
+  std::string architecture{};
   Configuration config{};
 
-  double time    = 0.0;
-  bool   timeout = true;
+  double time = 0.0;
+  bool timeout = true;
 
   CircuitInfo output{};
   std::string mappedCircuit{};
 
   std::string wcnf{};
 
-  HeuristicBenchmarkInfo                   heuristicBenchmark{};
+  HeuristicBenchmarkInfo heuristicBenchmark{};
   std::vector<LayerHeuristicBenchmarkInfo> layerHeuristicBenchmark{};
 
-  MappingResults()          = default;
+  MappingResults() = default;
   virtual ~MappingResults() = default;
 
   virtual void copyInput(const MappingResults& mappingResults) {
-    input                   = mappingResults.input;
-    architecture            = mappingResults.architecture;
-    config                  = mappingResults.config;
-    output                  = mappingResults.output;
-    wcnf                    = mappingResults.wcnf;
-    heuristicBenchmark      = mappingResults.heuristicBenchmark;
+    input = mappingResults.input;
+    architecture = mappingResults.architecture;
+    config = mappingResults.config;
+    output = mappingResults.output;
+    wcnf = mappingResults.wcnf;
+    heuristicBenchmark = mappingResults.heuristicBenchmark;
     layerHeuristicBenchmark = mappingResults.layerHeuristicBenchmark;
   }
 
@@ -117,32 +117,32 @@ struct MappingResults {
   [[nodiscard]] virtual nlohmann::json json() const {
     nlohmann::json resultJSON{};
 
-    auto& circuit                 = resultJSON["circuit"];
-    circuit["name"]               = input.name;
-    circuit["qubits"]             = input.qubits;
-    circuit["gates"]              = input.gates;
+    auto& circuit = resultJSON["circuit"];
+    circuit["name"] = input.name;
+    circuit["qubits"] = input.qubits;
+    circuit["gates"] = input.gates;
     circuit["single_qubit_gates"] = input.singleQubitGates;
-    circuit["cnots"]              = input.cnots;
+    circuit["cnots"] = input.cnots;
 
-    auto& mappedCirc                 = resultJSON["mapped_circuit"];
-    mappedCirc["name"]               = output.name;
-    mappedCirc["qubits"]             = output.qubits;
-    mappedCirc["gates"]              = output.gates;
+    auto& mappedCirc = resultJSON["mapped_circuit"];
+    mappedCirc["name"] = output.name;
+    mappedCirc["qubits"] = output.qubits;
+    mappedCirc["gates"] = output.gates;
     mappedCirc["single_qubit_gates"] = output.singleQubitGates;
-    mappedCirc["cnots"]              = output.cnots;
+    mappedCirc["cnots"] = output.cnots;
     if (!mappedCircuit.empty()) {
       mappedCirc["qasm"] = mappedCircuit;
     }
 
     resultJSON["config"] = config.json();
 
-    auto& stats                 = resultJSON["statistics"];
-    stats["timeout"]            = timeout;
-    stats["mapping_time"]       = time;
-    stats["arch"]               = architecture;
-    stats["layers"]             = input.layers;
-    stats["swaps"]              = output.swaps;
-    stats["total_fidelity"]     = output.totalFidelity;
+    auto& stats = resultJSON["statistics"];
+    stats["timeout"] = timeout;
+    stats["mapping_time"] = time;
+    stats["arch"] = architecture;
+    stats["layers"] = input.layers;
+    stats["swaps"] = output.swaps;
+    stats["total_fidelity"] = output.totalFidelity;
     stats["total_log_fidelity"] = output.totalLogFidelity;
     if (config.method == Method::Exact) {
       stats["direction_reverse"] = output.directionReverse;
@@ -151,7 +151,7 @@ struct MappingResults {
       }
     } else if (config.method == Method::Heuristic) {
       stats["teleportations"] = output.teleportations;
-      stats["benchmark"]      = heuristicBenchmark.json();
+      stats["benchmark"] = heuristicBenchmark.json();
     }
     stats["additional_gates"] =
         static_cast<std::make_signed_t<decltype(output.gates)>>(output.gates) -

--- a/include/MappingResults.hpp
+++ b/include/MappingResults.hpp
@@ -3,19 +3,24 @@
 // See README.md or go to https://github.com/cda-tum/qmap for more information.
 //
 
-#include "Architecture.hpp"
 #include "configuration/Configuration.hpp"
+#include "configuration/Method.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 #pragma once
 
 struct MappingResults {
   struct CircuitInfo {
     // general info
-    std::string name{};
+    std::string name;
     std::uint16_t qubits = 0;
     std::size_t gates = 0;
     std::size_t singleQubitGates = 0;
@@ -39,8 +44,8 @@ struct MappingResults {
     double averageBranchingFactor = 0.;
     double effectiveBranchingFactor = 0.;
 
-    [[nodiscard]] nlohmann::json json() const {
-      nlohmann::json resultJSON{};
+    [[nodiscard]] nlohmann::basic_json<> json() const {
+      nlohmann::basic_json resultJSON{};
       resultJSON["expanded_nodes"] = expandedNodes;
       resultJSON["generated_nodes"] = generatedNodes;
       resultJSON["seconds_per_node"] = secondsPerNode;
@@ -63,8 +68,8 @@ struct MappingResults {
     double effectiveBranchingFactor = 0.;
     bool earlyTermination = false;
 
-    [[nodiscard]] nlohmann::json json() const {
-      nlohmann::json resultJSON{};
+    [[nodiscard]] nlohmann::basic_json<> json() const {
+      nlohmann::basic_json resultJSON{};
       resultJSON["expanded_nodes"] = expandedNodes;
       resultJSON["generated_nodes"] = generatedNodes;
       resultJSON["expanded_nodes_after_first_solution"] =
@@ -85,19 +90,19 @@ struct MappingResults {
 
   CircuitInfo input{};
 
-  std::string architecture{};
+  std::string architecture;
   Configuration config{};
 
   double time = 0.0;
   bool timeout = true;
 
   CircuitInfo output{};
-  std::string mappedCircuit{};
+  std::string mappedCircuit;
 
-  std::string wcnf{};
+  std::string wcnf;
 
   HeuristicBenchmarkInfo heuristicBenchmark{};
-  std::vector<LayerHeuristicBenchmarkInfo> layerHeuristicBenchmark{};
+  std::vector<LayerHeuristicBenchmarkInfo> layerHeuristicBenchmark;
 
   MappingResults() = default;
   virtual ~MappingResults() = default;
@@ -114,8 +119,8 @@ struct MappingResults {
 
   [[nodiscard]] std::string toString() const { return json().dump(2); }
 
-  [[nodiscard]] virtual nlohmann::json json() const {
-    nlohmann::json resultJSON{};
+  [[nodiscard]] virtual nlohmann::basic_json<> json() const {
+    nlohmann::basic_json resultJSON{};
 
     auto& circuit = resultJSON["circuit"];
     circuit["name"] = input.name;

--- a/include/cliffordsynthesis/CliffordSynthesizer.hpp
+++ b/include/cliffordsynthesis/CliffordSynthesizer.hpp
@@ -37,7 +37,7 @@ public:
         initialCircuit(std::make_shared<qc::QuantumComputation>(qc)),
         results(qc, targetTableau) {}
   explicit CliffordSynthesizer(qc::QuantumComputation& qc,
-                               const bool              useDestabilizers = false)
+                               const bool useDestabilizers = false)
       : initialTableau(qc.getNqubits(), useDestabilizers),
         targetTableau(qc, 0, std::numeric_limits<std::size_t>::max(),
                       useDestabilizers),
@@ -69,16 +69,16 @@ public:
   }
 
 protected:
-  Tableau                                 initialTableau{};
-  Tableau                                 targetTableau{};
+  Tableau initialTableau{};
+  Tableau targetTableau{};
   std::shared_ptr<qc::QuantumComputation> initialCircuit{};
 
   Configuration configuration{};
 
-  Results                                 results{};
+  Results results{};
   std::shared_ptr<qc::QuantumComputation> resultCircuit{};
-  Tableau                                 resultTableau{};
-  std::size_t                             solverCalls{};
+  Tableau resultTableau{};
+  std::size_t solverCalls{};
 
   static bool requiresMultiGateEncoding(const TargetMetric metric) {
     return metric == TargetMetric::Depth;
@@ -86,8 +86,8 @@ protected:
 
   void determineInitialTimestepLimit(EncoderConfig& config);
   std::pair<std::size_t, std::size_t> determineUpperBound(EncoderConfig config);
-  void                                runMaxSAT(const EncoderConfig& config);
-  Results                             callSolver(const EncoderConfig& config);
+  void runMaxSAT(const EncoderConfig& config);
+  Results callSolver(const EncoderConfig& config);
 
   void minimizeGatesFixedDepth(EncoderConfig config);
 
@@ -99,7 +99,7 @@ protected:
   void twoQubitGateOptimalSynthesis(EncoderConfig config, std::size_t lower,
                                     std::size_t upper);
 
-  void minimizeTwoQubitGatesFixedGateCount(std::size_t   gateCount,
+  void minimizeTwoQubitGatesFixedGateCount(std::size_t gateCount,
                                            EncoderConfig config);
   void minimizeGatesFixedTwoQubitGateCount(EncoderConfig config);
 
@@ -155,7 +155,7 @@ protected:
                        const Configuration& config);
   static void updateResults(const Configuration& config,
                             const Results& newResults, Results& currentResults);
-  void        removeRedundantGates();
+  void removeRedundantGates();
 };
 
 } // namespace cs

--- a/include/cliffordsynthesis/CliffordSynthesizer.hpp
+++ b/include/cliffordsynthesis/CliffordSynthesizer.hpp
@@ -5,16 +5,18 @@
 
 #pragma once
 
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
 #include "cliffordsynthesis/Configuration.hpp"
 #include "cliffordsynthesis/Results.hpp"
 #include "cliffordsynthesis/Tableau.hpp"
+#include "cliffordsynthesis/TargetMetric.hpp"
 #include "cliffordsynthesis/encoding/SATEncoder.hpp"
-#include "plog/Log.h"
 
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <plog/Log.h>
 #include <sstream>
 #include <utility>
 
@@ -69,15 +71,15 @@ public:
   }
 
 protected:
-  Tableau initialTableau{};
-  Tableau targetTableau{};
-  std::shared_ptr<qc::QuantumComputation> initialCircuit{};
+  Tableau initialTableau;
+  Tableau targetTableau;
+  std::shared_ptr<qc::QuantumComputation> initialCircuit;
 
   Configuration configuration{};
 
-  Results results{};
-  std::shared_ptr<qc::QuantumComputation> resultCircuit{};
-  Tableau resultTableau{};
+  Results results;
+  std::shared_ptr<qc::QuantumComputation> resultCircuit;
+  Tableau resultTableau;
   std::size_t solverCalls{};
 
   static bool requiresMultiGateEncoding(const TargetMetric metric) {

--- a/include/cliffordsynthesis/Configuration.hpp
+++ b/include/cliffordsynthesis/Configuration.hpp
@@ -22,15 +22,15 @@ struct Configuration {
   Configuration() = default;
 
   /// General configuration for the synthesis algorithm
-  std::size_t    initialTimestepLimit    = 0U;
-  std::size_t    minimalTimesteps        = 0U;
-  bool           useMaxSAT               = false;
-  bool           linearSearch            = false;
-  TargetMetric   target                  = TargetMetric::Gates;
-  bool           useSymmetryBreaking     = true;
-  bool           dumpIntermediateResults = false;
-  std::string    intermediateResultsPath = "./";
-  plog::Severity verbosity               = plog::Severity::warning;
+  std::size_t initialTimestepLimit = 0U;
+  std::size_t minimalTimesteps = 0U;
+  bool useMaxSAT = false;
+  bool linearSearch = false;
+  TargetMetric target = TargetMetric::Gates;
+  bool useSymmetryBreaking = true;
+  bool dumpIntermediateResults = false;
+  std::string intermediateResultsPath = "./";
+  plog::Severity verbosity = plog::Severity::warning;
 
   /// Settings for the SAT solver
   SolverParameterMap solverParameters = {};
@@ -39,23 +39,23 @@ struct Configuration {
   bool minimizeGatesAfterDepthOptimization = false;
 
   /// Settings for two-qubit gate-optimal synthesis
-  bool   tryHigherGateLimitForTwoQubitGateOptimization = false;
-  double gateLimitFactor                               = 1.1;
-  bool   minimizeGatesAfterTwoQubitGateOptimization    = false;
+  bool tryHigherGateLimitForTwoQubitGateOptimization = false;
+  double gateLimitFactor = 1.1;
+  bool minimizeGatesAfterTwoQubitGateOptimization = false;
 
   // Settings for the heuristic solver
-  bool        heuristic         = false;
-  std::size_t splitSize         = 5U;
+  bool heuristic = false;
+  std::size_t splitSize = 5U;
   std::size_t nThreadsHeuristic = std::thread::hardware_concurrency();
 
   [[nodiscard]] nlohmann::json json() const {
     nlohmann::json j;
     j["initial_timestep_limit"] = initialTimestepLimit;
-    j["minimal_timesteps"]      = minimalTimesteps;
-    j["use_max_sat"]            = useMaxSAT;
-    j["linear_search"]          = linearSearch;
-    j["target_metric"]          = toString(target);
-    j["use_symmetry_breaking"]  = useSymmetryBreaking;
+    j["minimal_timesteps"] = minimalTimesteps;
+    j["use_max_sat"] = useMaxSAT;
+    j["linear_search"] = linearSearch;
+    j["target_metric"] = toString(target);
+    j["use_symmetry_breaking"] = useSymmetryBreaking;
     j["minimize_gates_after_depth_optimization"] =
         minimizeGatesAfterDepthOptimization;
     j["try_higher_gate_limit_for_two_qubit_gate_optimization"] =
@@ -63,8 +63,8 @@ struct Configuration {
     j["gate_limit_factor"] = gateLimitFactor;
     j["minimize_gates_after_two_qubit_gate_optimization"] =
         minimizeGatesAfterTwoQubitGateOptimization;
-    j["heuristic"]           = heuristic;
-    j["split_size"]          = splitSize;
+    j["heuristic"] = heuristic;
+    j["split_size"] = splitSize;
     j["n_threads_heuristic"] = nThreadsHeuristic;
     if (!solverParameters.empty()) {
       nlohmann::json solverParametersJson;
@@ -80,7 +80,7 @@ struct Configuration {
     return j;
   }
 
-  friend std::ostream& operator<<(std::ostream&        os,
+  friend std::ostream& operator<<(std::ostream& os,
                                   const Configuration& config) {
     os << config.json().dump(2);
     return os;

--- a/include/cliffordsynthesis/Configuration.hpp
+++ b/include/cliffordsynthesis/Configuration.hpp
@@ -6,9 +6,13 @@
 #pragma once
 
 #include "TargetMetric.hpp"
-#include "nlohmann/json.hpp"
 
-#include <plog/Log.h>
+#include <cstddef>
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <ostream>
+#include <plog/Severity.h>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <variant>
@@ -33,7 +37,7 @@ struct Configuration {
   plog::Severity verbosity = plog::Severity::warning;
 
   /// Settings for the SAT solver
-  SolverParameterMap solverParameters = {};
+  SolverParameterMap solverParameters;
 
   /// Settings for depth-optimal synthesis
   bool minimizeGatesAfterDepthOptimization = false;
@@ -48,8 +52,8 @@ struct Configuration {
   std::size_t splitSize = 5U;
   std::size_t nThreadsHeuristic = std::thread::hardware_concurrency();
 
-  [[nodiscard]] nlohmann::json json() const {
-    nlohmann::json j;
+  [[nodiscard]] nlohmann::basic_json<> json() const {
+    nlohmann::basic_json j;
     j["initial_timestep_limit"] = initialTimestepLimit;
     j["minimal_timesteps"] = minimalTimesteps;
     j["use_max_sat"] = useMaxSAT;
@@ -67,7 +71,7 @@ struct Configuration {
     j["split_size"] = splitSize;
     j["n_threads_heuristic"] = nThreadsHeuristic;
     if (!solverParameters.empty()) {
-      nlohmann::json solverParametersJson;
+      nlohmann::basic_json solverParametersJson;
       for (const auto& entry : solverParameters) {
         std::visit(
             [&solverParametersJson, &entry](const auto& v) {

--- a/include/cliffordsynthesis/Results.hpp
+++ b/include/cliffordsynthesis/Results.hpp
@@ -39,8 +39,8 @@ public:
   [[nodiscard]] std::size_t getSingleQubitGates() const {
     return singleQubitGates;
   }
-  [[nodiscard]] std::size_t       getDepth() const { return depth; }
-  [[nodiscard]] double            getRuntime() const { return runtime; }
+  [[nodiscard]] std::size_t getDepth() const { return depth; }
+  [[nodiscard]] double getRuntime() const { return runtime; }
   [[nodiscard]] logicbase::Result getSolverResult() const {
     return solverResult;
   }
@@ -76,12 +76,12 @@ public:
 
   [[nodiscard]] virtual nlohmann::json json() const {
     nlohmann::json resultJSON{};
-    resultJSON["solver_result"]      = toString(solverResult);
+    resultJSON["solver_result"] = toString(solverResult);
     resultJSON["single_qubit_gates"] = singleQubitGates;
-    resultJSON["two_qubit_gates"]    = twoQubitGates;
-    resultJSON["depth"]              = depth;
-    resultJSON["runtime"]            = runtime;
-    resultJSON["solver_calls"]       = solverCalls;
+    resultJSON["two_qubit_gates"] = twoQubitGates;
+    resultJSON["depth"] = depth;
+    resultJSON["runtime"] = runtime;
+    resultJSON["solver_calls"] = solverCalls;
 
     return resultJSON;
   }
@@ -92,12 +92,12 @@ public:
   }
 
 protected:
-  logicbase::Result solverResult     = logicbase::Result::NDEF;
-  std::size_t       singleQubitGates = std::numeric_limits<std::size_t>::max();
-  std::size_t       twoQubitGates    = std::numeric_limits<std::size_t>::max();
-  std::size_t       depth            = std::numeric_limits<std::size_t>::max();
-  double            runtime          = 0.0;
-  std::size_t       solverCalls      = 0U;
+  logicbase::Result solverResult = logicbase::Result::NDEF;
+  std::size_t singleQubitGates = std::numeric_limits<std::size_t>::max();
+  std::size_t twoQubitGates = std::numeric_limits<std::size_t>::max();
+  std::size_t depth = std::numeric_limits<std::size_t>::max();
+  double runtime = 0.0;
+  std::size_t solverCalls = 0U;
 
   std::string resultTableau{};
   std::string resultCircuit{};

--- a/include/cliffordsynthesis/Results.hpp
+++ b/include/cliffordsynthesis/Results.hpp
@@ -6,10 +6,14 @@
 #pragma once
 
 #include "CircuitOptimizer.hpp"
+#include "QuantumComputation.hpp"
 #include "cliffordsynthesis/Tableau.hpp"
 #include "logicblocks/Logic.hpp"
 
+#include <cstddef>
+#include <limits>
 #include <nlohmann/json.hpp>
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -74,8 +78,8 @@ public:
     return getSolverResult() == logicbase::Result::UNSAT;
   }
 
-  [[nodiscard]] virtual nlohmann::json json() const {
-    nlohmann::json resultJSON{};
+  [[nodiscard]] virtual nlohmann::basic_json<> json() const {
+    nlohmann::basic_json resultJSON{};
     resultJSON["solver_result"] = toString(solverResult);
     resultJSON["single_qubit_gates"] = singleQubitGates;
     resultJSON["two_qubit_gates"] = twoQubitGates;
@@ -99,8 +103,8 @@ protected:
   double runtime = 0.0;
   std::size_t solverCalls = 0U;
 
-  std::string resultTableau{};
-  std::string resultCircuit{};
+  std::string resultTableau;
+  std::string resultCircuit;
 };
 
 } // namespace cs

--- a/include/cliffordsynthesis/Tableau.hpp
+++ b/include/cliffordsynthesis/Tableau.hpp
@@ -6,13 +6,18 @@
 #pragma once
 
 #include "QuantumComputation.hpp"
-#include "plog/Log.h"
+#include "operations/Operation.hpp"
 
+#include <bitset>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
-#include <fstream>
+#include <istream>
 #include <limits>
 #include <ostream>
-#include <utility>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace cs {

--- a/include/cliffordsynthesis/Tableau.hpp
+++ b/include/cliffordsynthesis/Tableau.hpp
@@ -17,23 +17,23 @@
 
 namespace cs {
 class Tableau {
-  using EntryType   = std::uint8_t;
-  using RowType     = std::vector<EntryType>;
+  using EntryType = std::uint8_t;
+  using RowType = std::vector<EntryType>;
   using TableauType = std::vector<RowType>;
   std::size_t nQubits{};
   TableauType tableau;
 
 private:
-  void           loadStabilizerDestabilizerString(const std::string& string);
+  void loadStabilizerDestabilizerString(const std::string& string);
   static RowType parseStabilizer(const std::string& stab);
 
 public:
   Tableau() = default;
   explicit Tableau(const qc::QuantumComputation& qc, std::size_t begin = 0,
                    std::size_t end = std::numeric_limits<std::size_t>::max(),
-                   bool        includeDestabilizers = false);
+                   bool includeDestabilizers = false);
   explicit Tableau(const std::size_t nq,
-                   const bool        includeDestabilizers = false)
+                   const bool includeDestabilizers = false)
       : nQubits(nq) {
     createDiagonalTableau(nq, includeDestabilizers);
   }
@@ -139,7 +139,7 @@ public:
   }
 
   [[nodiscard]] std::string toString() const;
-  void                      fromString(const std::string& str);
+  void fromString(const std::string& str);
 
   void fromString(const std::string& stabilizers,
                   const std::string& destabilizers);

--- a/include/cliffordsynthesis/TargetMetric.hpp
+++ b/include/cliffordsynthesis/TargetMetric.hpp
@@ -5,11 +5,11 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
 #include <string>
 
 namespace cs {
-enum class TargetMetric { Gates, TwoQubitGates, Depth };
+enum class TargetMetric : std::uint8_t { Gates, TwoQubitGates, Depth };
 
 [[maybe_unused]] static inline std::string toString(const TargetMetric target) {
   switch (target) {

--- a/include/cliffordsynthesis/encoding/GateEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/GateEncoder.hpp
@@ -5,13 +5,20 @@
 
 #pragma once
 
+#include "QuantumComputation.hpp"
 #include "cliffordsynthesis/Results.hpp"
 #include "cliffordsynthesis/encoding/TableauEncoder.hpp"
+#include "logicblocks/Logic.hpp"
 #include "logicblocks/LogicBlock.hpp"
+#include "logicblocks/LogicTerm.hpp"
 #include "operations/OpType.hpp"
 
+#include <array>
 #include <cstddef>
+#include <functional>
 #include <memory>
+#include <utility>
+#include <vector>
 
 namespace cs::encoding {
 
@@ -27,9 +34,9 @@ public:
 
   struct Variables {
     // variables for the single-qubit gates
-    logicbase::LogicMatrix3D gS{};
+    logicbase::LogicMatrix3D gS;
     // variables for the two-qubit gates
-    logicbase::LogicMatrix3D gC{};
+    logicbase::LogicMatrix3D gC;
 
     void
     collectSingleQubitGateVariables(std::size_t pos, std::size_t qubit,
@@ -115,7 +122,7 @@ protected:
   TableauEncoder::Variables* tvars{};
 
   // the logic block to use
-  std::shared_ptr<logicbase::LogicBlock> lb{};
+  std::shared_ptr<logicbase::LogicBlock> lb;
 
   using TransformationFamily =
       std::pair<logicbase::LogicTerm, std::vector<qc::OpType>>;

--- a/include/cliffordsynthesis/encoding/GateEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/GateEncoder.hpp
@@ -18,8 +18,8 @@ namespace cs::encoding {
 class GateEncoder {
 public:
   GateEncoder(const std::size_t nQubits, const std::size_t tableauSize,
-              const std::size_t                      timestepLimit,
-              TableauEncoder::Variables*             tableauVars,
+              const std::size_t timestepLimit,
+              TableauEncoder::Variables* tableauVars,
               std::shared_ptr<logicbase::LogicBlock> logicBlock)
       : N(nQubits), S(tableauSize), T(timestepLimit), tvars(tableauVars),
         lb(std::move(logicBlock)) {}
@@ -32,10 +32,10 @@ public:
     logicbase::LogicMatrix3D gC{};
 
     void
-         collectSingleQubitGateVariables(std::size_t pos, std::size_t qubit,
-                                         logicbase::LogicVector& variables) const;
+    collectSingleQubitGateVariables(std::size_t pos, std::size_t qubit,
+                                    logicbase::LogicVector& variables) const;
     void collectTwoQubitGateVariables(std::size_t pos, std::size_t qubit,
-                                      bool                    target,
+                                      bool target,
                                       logicbase::LogicVector& variables) const;
   };
 
@@ -126,12 +126,12 @@ protected:
 
   virtual void assertConsistency() const = 0;
 
-  virtual void assertGateConstraints()                           = 0;
+  virtual void assertGateConstraints() = 0;
   virtual void assertSingleQubitGateConstraints(std::size_t pos) = 0;
-  virtual void assertTwoQubitGateConstraints(std::size_t pos)    = 0;
+  virtual void assertTwoQubitGateConstraints(std::size_t pos) = 0;
   [[nodiscard]] static std::vector<TransformationFamily>
-       collectGateTransformations(std::size_t pos, std::size_t qubit,
-                                  const GateToTransformation& gateToTransformation);
+  collectGateTransformations(std::size_t pos, std::size_t qubit,
+                             const GateToTransformation& gateToTransformation);
   void assertGatesImplyTransform(
       std::size_t pos, std::size_t qubit,
       const std::vector<TransformationFamily>& transformations);
@@ -142,13 +142,13 @@ protected:
   createTwoQubitGateConstraint(std::size_t pos, std::size_t ctrl,
                                std::size_t trgt) = 0;
 
-  void extractSingleQubitGatesFromModel(std::size_t             pos,
-                                        logicbase::Model&       model,
+  void extractSingleQubitGatesFromModel(std::size_t pos,
+                                        logicbase::Model& model,
                                         qc::QuantumComputation& qc,
                                         std::size_t& nSingleQubitGates);
   void extractTwoQubitGatesFromModel(std::size_t pos, logicbase::Model& model,
                                      qc::QuantumComputation& qc,
-                                     std::size_t&            nTwoQubitGates);
+                                     std::size_t& nTwoQubitGates);
 
   virtual void
   assertSingleQubitGateSymmetryBreakingConstraints(std::size_t pos);

--- a/include/cliffordsynthesis/encoding/MultiGateEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/MultiGateEncoder.hpp
@@ -6,9 +6,10 @@
 #pragma once
 
 #include "cliffordsynthesis/encoding/GateEncoder.hpp"
+#include "logicblocks/Logic.hpp"
+#include "logicblocks/LogicTerm.hpp"
 
 #include <cstddef>
-#include <optional>
 
 namespace cs::encoding {
 
@@ -17,8 +18,8 @@ public:
   using GateEncoder::GateEncoder;
 
 protected:
-  logicbase::LogicTerm rChanges{};
-  logicbase::LogicMatrix xorHelpers{};
+  logicbase::LogicTerm rChanges;
+  logicbase::LogicMatrix xorHelpers;
 
   void assertConsistency() const override;
   void assertGateConstraints() override;

--- a/include/cliffordsynthesis/encoding/MultiGateEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/MultiGateEncoder.hpp
@@ -17,7 +17,7 @@ public:
   using GateEncoder::GateEncoder;
 
 protected:
-  logicbase::LogicTerm   rChanges{};
+  logicbase::LogicTerm rChanges{};
   logicbase::LogicMatrix xorHelpers{};
 
   void assertConsistency() const override;

--- a/include/cliffordsynthesis/encoding/ObjectiveEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/ObjectiveEncoder.hpp
@@ -7,11 +7,14 @@
 
 #include "cliffordsynthesis/TargetMetric.hpp"
 #include "cliffordsynthesis/encoding/GateEncoder.hpp"
-#include "cliffordsynthesis/encoding/TableauEncoder.hpp"
+#include "logicblocks/LogicBlock.hpp"
+#include "logicblocks/LogicTerm.hpp"
+#include "operations/OpType.hpp"
 
 #include <cstddef>
-#include <functional>
 #include <memory>
+#include <plog/Log.h>
+#include <utility>
 
 namespace cs::encoding {
 

--- a/include/cliffordsynthesis/encoding/ObjectiveEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/ObjectiveEncoder.hpp
@@ -18,7 +18,7 @@ namespace cs::encoding {
 class ObjectiveEncoder {
 public:
   ObjectiveEncoder(const std::size_t nQubits, const std::size_t timestepLimit,
-                   GateEncoder::Variables*                vars,
+                   GateEncoder::Variables* vars,
                    std::shared_ptr<logicbase::LogicBlock> logicBlock)
       : N(nQubits), T(timestepLimit), gvars(vars), lb(std::move(logicBlock)) {}
 

--- a/include/cliffordsynthesis/encoding/SATEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/SATEncoder.hpp
@@ -8,11 +8,12 @@
 #include "cliffordsynthesis/Configuration.hpp"
 #include "cliffordsynthesis/Results.hpp"
 #include "cliffordsynthesis/Tableau.hpp"
+#include "cliffordsynthesis/TargetMetric.hpp"
 #include "cliffordsynthesis/encoding/GateEncoder.hpp"
 #include "cliffordsynthesis/encoding/ObjectiveEncoder.hpp"
 #include "cliffordsynthesis/encoding/TableauEncoder.hpp"
+#include "logicblocks/Logic.hpp"
 #include "logicblocks/LogicBlock.hpp"
-#include "operations/OpType.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -56,7 +57,7 @@ public:
     // an optional limit on the total number of two-qubit gates
     std::optional<std::size_t> twoQubitGateLimit = std::nullopt;
 
-    SolverParameterMap solverParameters = {};
+    SolverParameterMap solverParameters;
   };
 
   SATEncoder() = default;

--- a/include/cliffordsynthesis/encoding/SATEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/SATEncoder.hpp
@@ -68,16 +68,16 @@ public:
   virtual Results run();
 
 protected:
-  void                            initializeSolver();
-  void                            createFormulation();
+  void initializeSolver();
+  void createFormulation();
   [[nodiscard]] logicbase::Result solve() const;
-  void                            extractResultsFromModel(Results& res) const;
-  void                            cleanup() const;
+  void extractResultsFromModel(Results& res) const;
+  void cleanup() const;
 
   std::shared_ptr<logicbase::LogicBlock> lb;
-  std::shared_ptr<TableauEncoder>        tableauEncoder;
-  std::shared_ptr<GateEncoder>           gateEncoder;
-  std::shared_ptr<ObjectiveEncoder>      objectiveEncoder;
+  std::shared_ptr<TableauEncoder> tableauEncoder;
+  std::shared_ptr<GateEncoder> gateEncoder;
+  std::shared_ptr<ObjectiveEncoder> objectiveEncoder;
 
   // all configuration options for the encoder
   Configuration config{};

--- a/include/cliffordsynthesis/encoding/SingleGateEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/SingleGateEncoder.hpp
@@ -6,10 +6,9 @@
 #pragma once
 
 #include "cliffordsynthesis/encoding/GateEncoder.hpp"
+#include "logicblocks/LogicTerm.hpp"
 
 #include <cstddef>
-#include <functional>
-#include <optional>
 
 namespace cs::encoding {
 

--- a/include/cliffordsynthesis/encoding/TableauEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/TableauEncoder.hpp
@@ -18,7 +18,7 @@ class TableauEncoder {
 public:
   TableauEncoder() = default;
   TableauEncoder(const std::size_t nQubits, const std::size_t tableauSize,
-                 const std::size_t                      timestepLimit,
+                 const std::size_t timestepLimit,
                  std::shared_ptr<logicbase::LogicBlock> logicBlock)
       : N(nQubits), S(tableauSize), T(timestepLimit),
         lb(std::move(logicBlock)) {}

--- a/include/cliffordsynthesis/encoding/TableauEncoder.hpp
+++ b/include/cliffordsynthesis/encoding/TableauEncoder.hpp
@@ -7,10 +7,13 @@
 
 #include "cliffordsynthesis/Results.hpp"
 #include "cliffordsynthesis/Tableau.hpp"
+#include "logicblocks/Logic.hpp"
 #include "logicblocks/LogicBlock.hpp"
+#include "operations/OpType.hpp"
 
 #include <cstddef>
 #include <memory>
+#include <utility>
 
 namespace cs::encoding {
 
@@ -25,11 +28,11 @@ public:
 
   struct Variables {
     // variables for the X parts of the tableaus
-    logicbase::LogicMatrix x{};
+    logicbase::LogicMatrix x;
     // variables for the Z parts of the tableaus
-    logicbase::LogicMatrix z{};
+    logicbase::LogicMatrix z;
     // variables for the phase parts of the tableaus
-    logicbase::LogicVector r{};
+    logicbase::LogicVector r;
 
     // update rules for single-qubit gates
     [[nodiscard]] logicbase::LogicTerm
@@ -75,6 +78,6 @@ protected:
   Variables vars{};
 
   // the logic block to use
-  std::shared_ptr<logicbase::LogicBlock> lb{};
+  std::shared_ptr<logicbase::LogicBlock> lb;
 };
 } // namespace cs::encoding

--- a/include/configuration/AvailableArchitecture.hpp
+++ b/include/configuration/AvailableArchitecture.hpp
@@ -5,10 +5,12 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
 #include <map>
+#include <stdexcept>
+#include <string>
 
-enum class AvailableArchitecture {
+enum class AvailableArchitecture : std::uint8_t {
   IbmQx4,
   IbmQx5,
   IbmqYorktown,

--- a/include/configuration/CommanderGrouping.hpp
+++ b/include/configuration/CommanderGrouping.hpp
@@ -5,12 +5,21 @@
 
 #pragma once
 
+#include <cstdint>
+#include <istream>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 
-enum class CommanderGrouping { Halves, Fixed2, Fixed3, Logarithm };
+enum class CommanderGrouping : std::uint8_t {
+  Halves,
+  Fixed2,
+  Fixed3,
+  Logarithm
+};
 
-static inline std::string toString(const CommanderGrouping grouping) {
+[[maybe_unused]] static inline std::string
+toString(const CommanderGrouping grouping) {
   switch (grouping) {
   case CommanderGrouping::Fixed2:
     return "fixed2";
@@ -24,7 +33,8 @@ static inline std::string toString(const CommanderGrouping grouping) {
   return " ";
 }
 
-static CommanderGrouping groupingFromString(const std::string& grouping) {
+[[maybe_unused]] static CommanderGrouping
+groupingFromString(const std::string& grouping) {
   if (grouping == "halves" || grouping == "0") {
     return CommanderGrouping::Halves;
   }

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -14,9 +14,12 @@
 #include "LookaheadHeuristic.hpp"
 #include "Method.hpp"
 #include "SwapReduction.hpp"
-#include "nlohmann/json.hpp"
 
+#include <cstddef>
+#include <cstdint>
+#include <nlohmann/json.hpp>
 #include <set>
+#include <string>
 
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct Configuration {
@@ -38,7 +41,7 @@ struct Configuration {
   std::string dataLoggingPath;
 
   // map to particular subgraph of architecture (in exact mapper)
-  std::set<std::uint16_t> subgraph{};
+  std::set<std::uint16_t> subgraph;
 
   // how to cluster the gates into layers
   Layering layering = Layering::IndividualGates;
@@ -103,7 +106,7 @@ struct Configuration {
   SwapReduction swapReduction = SwapReduction::CouplingLimit;
   std::size_t swapLimit = 0;
 
-  [[nodiscard]] nlohmann::json json() const;
+  [[nodiscard]] nlohmann::basic_json<> json() const;
   [[nodiscard]] std::string toString() const { return json().dump(2); }
 
   [[nodiscard]] bool dataLoggingEnabled() const {

--- a/include/configuration/Configuration.hpp
+++ b/include/configuration/Configuration.hpp
@@ -23,18 +23,18 @@ struct Configuration {
   Configuration() = default;
 
   // which method to use
-  Method    method    = Method::Heuristic;
+  Method method = Method::Heuristic;
   Heuristic heuristic = Heuristic::GateCountMaxDistance;
 
-  bool preMappingOptimizations  = true;
+  bool preMappingOptimizations = true;
   bool postMappingOptimizations = true;
 
   bool addMeasurementsToMappedCircuit = true;
-  bool swapOnFirstLayer               = false;
-  bool addBarriersBetweenLayers       = false;
+  bool swapOnFirstLayer = false;
+  bool addBarriersBetweenLayers = false;
 
-  bool        verbose = false;
-  bool        debug   = false;
+  bool verbose = false;
+  bool debug = false;
   std::string dataLoggingPath;
 
   // map to particular subgraph of architecture (in exact mapper)
@@ -56,21 +56,21 @@ struct Configuration {
   // NISQ-era quantum devices", Proc. 24th Int. Conf. on Architectural Support
   // for Program. Languages and Oper. Syst. (ASPLOS)
   // https://arxiv.org/abs/1809.02573
-  bool        iterativeBidirectionalRouting       = false;
+  bool iterativeBidirectionalRouting = false;
   std::size_t iterativeBidirectionalRoutingPasses = 0;
 
   // lookahead scheme settings
   LookaheadHeuristic lookaheadHeuristic =
       LookaheadHeuristic::GateCountMaxDistance;
-  std::size_t nrLookaheads         = 15;
-  double      firstLookaheadFactor = 0.75;
-  double      lookaheadFactor      = 0.5;
+  std::size_t nrLookaheads = 15;
+  double firstLookaheadFactor = 0.75;
+  double lookaheadFactor = 0.5;
 
   // teleportation settings
-  bool          useTeleportation    = false;
-  std::size_t   teleportationQubits = 0;
-  std::uint64_t teleportationSeed   = 0;
-  bool          teleportationFake   = false;
+  bool useTeleportation = false;
+  std::size_t teleportationQubits = 0;
+  std::uint64_t teleportationSeed = 0;
+  bool teleportationFake = false;
 
   // timeout merely affects exact mapper
   std::size_t timeout = 3600000; // 60min timeout
@@ -79,17 +79,17 @@ struct Configuration {
   // nodes, thereby reducing the search space (but potentially eliminating
   // opportunities for cost savings); acts as a control between runtime and
   // result quality
-  bool        automaticLayerSplits          = true;
+  bool automaticLayerSplits = true;
   std::size_t automaticLayerSplitsNodeLimit = 5000;
 
   // strategy for terminating the heuristic search early (i.e. once a goal node
   // has been found, but before it is guaranteed that the optimal solution has
   // been found)
-  EarlyTermination earlyTermination      = EarlyTermination::None;
-  std::size_t      earlyTerminationLimit = 0;
+  EarlyTermination earlyTermination = EarlyTermination::None;
+  std::size_t earlyTerminationLimit = 0;
 
   // encoding of at most and exactly one constraints in exact mapper
-  Encoding          encoding          = Encoding::Commander;
+  Encoding encoding = Encoding::Commander;
   CommanderGrouping commanderGrouping = CommanderGrouping::Fixed3;
 
   // use qubit subsets in exact mapper
@@ -99,18 +99,18 @@ struct Configuration {
   bool includeWCNF = false;
 
   // limit the number of considered swaps
-  bool          enableSwapLimits = true;
-  SwapReduction swapReduction    = SwapReduction::CouplingLimit;
-  std::size_t   swapLimit        = 0;
+  bool enableSwapLimits = true;
+  SwapReduction swapReduction = SwapReduction::CouplingLimit;
+  std::size_t swapLimit = 0;
 
   [[nodiscard]] nlohmann::json json() const;
-  [[nodiscard]] std::string    toString() const { return json().dump(2); }
+  [[nodiscard]] std::string toString() const { return json().dump(2); }
 
   [[nodiscard]] bool dataLoggingEnabled() const {
     return !dataLoggingPath.empty();
   }
 
-  void               setTimeout(const std::size_t sec) { timeout = sec; }
+  void setTimeout(const std::size_t sec) { timeout = sec; }
   [[nodiscard]] bool swapLimitsEnabled() const {
     return (swapReduction != SwapReduction::None) && enableSwapLimits;
   }

--- a/include/configuration/EarlyTermination.hpp
+++ b/include/configuration/EarlyTermination.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
-enum class EarlyTermination {
+enum class EarlyTermination : std::uint8_t {
   None,
   ExpandedNodes,
   ExpandedNodesAfterFirstSolution,

--- a/include/configuration/Encoding.hpp
+++ b/include/configuration/Encoding.hpp
@@ -5,12 +5,15 @@
 
 #pragma once
 
+#include <cstdint>
+#include <istream>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 
-enum class Encoding { Naive, Commander, Bimander };
+enum class Encoding : std::uint8_t { Naive, Commander, Bimander };
 
-static inline std::string toString(const Encoding encoding) {
+[[maybe_unused]] static inline std::string toString(const Encoding encoding) {
   switch (encoding) {
   case Encoding::Naive:
     return "naive";
@@ -22,7 +25,8 @@ static inline std::string toString(const Encoding encoding) {
   return " ";
 }
 
-static Encoding encodingFromString(const std::string& encoding) {
+[[maybe_unused]] static Encoding
+encodingFromString(const std::string& encoding) {
   if (encoding == "naive" || encoding == "0") {
     return Encoding::Naive;
   }

--- a/include/configuration/Heuristic.hpp
+++ b/include/configuration/Heuristic.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
-enum class Heuristic {
+enum class Heuristic : std::uint8_t {
   /** maximum over all distances between any virtual qubit pair in the current
      layer; optimizing gate-count; admissible; tight */
   GateCountMaxDistance,

--- a/include/configuration/InitialLayout.hpp
+++ b/include/configuration/InitialLayout.hpp
@@ -5,12 +5,14 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
 /// Identity: q_i -> Q_i
 /// Static: first layer is mapped q_c -> Q_c and q_t -> Q_t
 /// Dynamic: Layout is generated on demand upon encountering a specific gate
-enum class InitialLayout { Identity, Static, Dynamic };
+enum class InitialLayout : std::uint8_t { Identity, Static, Dynamic };
 
 [[maybe_unused]] static inline std::string
 toString(const InitialLayout strategy) {

--- a/include/configuration/Layering.hpp
+++ b/include/configuration/Layering.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
-enum class Layering {
+enum class Layering : std::uint8_t {
   IndividualGates,
   DisjointQubits,
   OddGates,

--- a/include/configuration/LookaheadHeuristic.hpp
+++ b/include/configuration/LookaheadHeuristic.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
-enum class LookaheadHeuristic {
+enum class LookaheadHeuristic : std::uint8_t {
   /** no lookahead */
   None,
   /** maximum over all distances between any virtual qubit pair in the given

--- a/include/configuration/Method.hpp
+++ b/include/configuration/Method.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
-enum class Method { None, Exact, Heuristic };
+enum class Method : std::uint8_t { None, Exact, Heuristic };
 
 [[maybe_unused]] static inline std::string toString(const Method method) {
   switch (method) {

--- a/include/configuration/SwapReduction.hpp
+++ b/include/configuration/SwapReduction.hpp
@@ -5,9 +5,16 @@
 
 #pragma once
 
-#include <iostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
-enum class SwapReduction { None, CouplingLimit, Custom, Increasing };
+enum class SwapReduction : std::uint8_t {
+  None,
+  CouplingLimit,
+  Custom,
+  Increasing
+};
 
 [[maybe_unused]] static inline std::string
 toString(const SwapReduction strategy) {

--- a/include/exact/ExactMapper.hpp
+++ b/include/exact/ExactMapper.hpp
@@ -15,8 +15,8 @@
 #include <set>
 #include <unordered_set>
 
-using Swap        = std::pair<std::uint16_t, std::uint16_t>;
-using Swaps       = std::vector<Swap>;
+using Swap = std::pair<std::uint16_t, std::uint16_t>;
+using Swaps = std::vector<Swap>;
 using QubitChoice = std::set<std::uint16_t>;
 
 /// Main structure representing the circuit and mapping functionality
@@ -26,11 +26,11 @@ class ExactMapper : public Mapper {
 protected:
   // inputs
   std::vector<std::size_t> reducedLayerIndices{};
-  std::vector<Swaps>       mappingSwaps{};
-  void                     coreMappingRoutine(const QubitChoice& qubitChoice,
-                                              const CouplingMap& rcm, MappingResults& choiceResults,
-                                              std::vector<Swaps>& swaps, std::size_t limit,
-                                              std::size_t timeout);
+  std::vector<Swaps> mappingSwaps{};
+  void coreMappingRoutine(const QubitChoice& qubitChoice,
+                          const CouplingMap& rcm, MappingResults& choiceResults,
+                          std::vector<Swaps>& swaps, std::size_t limit,
+                          std::size_t timeout);
 
 public:
   void map(const Configuration& settings) override;

--- a/include/exact/ExactMapper.hpp
+++ b/include/exact/ExactMapper.hpp
@@ -6,14 +6,16 @@
 #pragma once
 
 #include "Mapper.hpp"
+#include "MappingResults.hpp"
+#include "configuration/Configuration.hpp"
+#include "utils.hpp"
 
-#include <algorithm>
-#include <bitset>
-#include <chrono>
 #include <cmath>
-#include <functional>
+#include <cstddef>
+#include <cstdint>
 #include <set>
-#include <unordered_set>
+#include <utility>
+#include <vector>
 
 using Swap = std::pair<std::uint16_t, std::uint16_t>;
 using Swaps = std::vector<Swap>;
@@ -25,8 +27,8 @@ class ExactMapper : public Mapper {
 
 protected:
   // inputs
-  std::vector<std::size_t> reducedLayerIndices{};
-  std::vector<Swaps> mappingSwaps{};
+  std::vector<std::size_t> reducedLayerIndices;
+  std::vector<Swaps> mappingSwaps;
   void coreMappingRoutine(const QubitChoice& qubitChoice,
                           const CouplingMap& rcm, MappingResults& choiceResults,
                           std::vector<Swaps>& swaps, std::size_t limit,

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -3,11 +3,21 @@
 // See README.md or go to https://github.com/cda-tum/qmap for more information.
 //
 
+#include "Architecture.hpp"
 #include "DataLogger.hpp"
 #include "Mapper.hpp"
+#include "configuration/Configuration.hpp"
 #include "heuristic/UniquePriorityQueue.hpp"
+#include "utils.hpp"
 
+#include <array>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <vector>
 
 #pragma once
 
@@ -31,10 +41,10 @@ public:
    */
   struct Node {
     /** gates (pair of logical qubits) currently mapped next to each other */
-    std::set<Edge> validMappedTwoQubitGates = {};
+    std::set<Edge> validMappedTwoQubitGates;
     /** swaps used so far to get from the initial mapping of the current layer
      * to the current mapping in this node */
-    std::vector<Exchange> swaps = {};
+    std::vector<Exchange> swaps;
     /**
      * containing the logical qubit currently mapped to each physical qubit.
      * `qubits[physical_qubit] = logical_qubit`

--- a/include/heuristic/HeuristicMapper.hpp
+++ b/include/heuristic/HeuristicMapper.hpp
@@ -71,9 +71,9 @@ public:
      * that both qubits got closer to being validly mapped*/
     std::size_t sharedSwaps = 0;
     /** depth in search tree (starting with 0 at the root) */
-    std::size_t depth  = 0;
+    std::size_t depth = 0;
     std::size_t parent = 0;
-    std::size_t id     = 0;
+    std::size_t id = 0;
     /** true if all qubit pairs are mapped next to each other on the
      * architecture */
     bool validMapping = true;
@@ -89,12 +89,12 @@ public:
     Node(std::size_t nodeId, std::size_t parentId,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& q,
          const std::array<std::int16_t, MAX_DEVICE_QUBITS>& loc,
-         const std::vector<Exchange>&                       sw            = {},
-         const std::set<Edge>&                              valid2QGates  = {},
-         const double                                       initCostFixed = 0,
-         const double      initCostFixedReversals                         = 0,
-         const std::size_t searchDepth                                    = 0,
-         const std::size_t initSharedSwaps                                = 0)
+         const std::vector<Exchange>& sw = {},
+         const std::set<Edge>& valid2QGates = {},
+         const double initCostFixed = 0,
+         const double initCostFixedReversals = 0,
+         const std::size_t searchDepth = 0,
+         const std::size_t initSharedSwaps = 0)
         : validMappedTwoQubitGates(valid2QGates), swaps(sw), qubits(q),
           locations(loc), costFixed(initCostFixed),
           costFixedReversals(initCostFixedReversals),
@@ -133,12 +133,12 @@ public:
   };
 
 protected:
-  UniquePriorityQueue<Node>   nodes{};
+  UniquePriorityQueue<Node> nodes{};
   std::unique_ptr<DataLogger> dataLogger;
-  std::size_t                 nextNodeId                = 0;
-  bool                        principallyAdmissibleHeur = true;
-  bool                        tightHeur                 = true;
-  bool                        fidelityAwareHeur         = false;
+  std::size_t nextNodeId = 0;
+  bool principallyAdmissibleHeur = true;
+  bool tightHeur = true;
+  bool fidelityAwareHeur = false;
 
   /**
    * @brief check the `results.config` for any invalid settings
@@ -348,7 +348,7 @@ protected:
    * @return heuristic cost
    */
   double heuristicGateCountSumDistanceMinusSharedSwaps(std::size_t layer,
-                                                       Node&       node);
+                                                       Node& node);
 
   /**
    * @brief calculates the heuristic using
@@ -361,7 +361,7 @@ protected:
    */
   double
   heuristicGateCountMaxDistanceOrSumDistanceMinusSharedSwaps(std::size_t layer,
-                                                             Node&       node);
+                                                             Node& node);
 
   /**
    * @brief calculates the heuristic using
@@ -408,7 +408,7 @@ protected:
    */
   double lookaheadGateCountSumDistance(std::size_t layer, Node& node);
 
-  static double computeEffectiveBranchingRate(std::size_t       nodesProcessed,
+  static double computeEffectiveBranchingRate(std::size_t nodesProcessed,
                                               const std::size_t solutionDepth) {
     // N = (b*)^d + (b*)^(d-1) + ... + (b*)^2 + b* + 1
     // no closed-form solution for b*, so we use approximation via binary search
@@ -421,7 +421,7 @@ protected:
     double lower = upper / static_cast<double>(solutionDepth);
     while (upper - lower > 2 * EFFECTIVE_BRANCH_RATE_TOLERANCE) {
       const double mid = (lower + upper) / 2.0;
-      double       sum = 0.0;
+      double sum = 0.0;
       for (std::size_t i = 1; i <= solutionDepth; ++i) {
         sum += std::pow(mid, i);
       }

--- a/include/heuristic/UniquePriorityQueue.hpp
+++ b/include/heuristic/UniquePriorityQueue.hpp
@@ -12,9 +12,9 @@
 
 #pragma once
 
-constexpr int    MAX_QUEUE_SIZE               = 6000000;
-constexpr int    MAX_NODES_MARGIN             = 500000;
-constexpr int    MAX_QUEUE_COPY_LENGTH        = 1000000;
+constexpr int MAX_QUEUE_SIZE = 6000000;
+constexpr int MAX_NODES_MARGIN = 500000;
+constexpr int MAX_QUEUE_COPY_LENGTH = 1000000;
 constexpr double QUEUE_COPY_LENGTH_PERCENTAGE = 1. / 6;
 
 template <class T> struct DoNothing {
@@ -37,7 +37,7 @@ public:
  * functions.
  */
 template <class T, class CostCompare = std::greater<T>,
-          class FuncCompare          = std::less<T>,
+          class FuncCompare = std::less<T>,
           class CleanObsoleteElement = DoNothing<T>>
 class UniquePriorityQueue {
 public:
@@ -78,7 +78,7 @@ public:
   void pop() {
     assert(!queue.empty() && queue.size() == membership.size());
 
-    const auto&                 topElement   = queue.top();
+    const auto& topElement = queue.top();
     [[maybe_unused]] const auto numberErased = membership.erase(topElement);
     assert(numberErased == 1);
 
@@ -106,14 +106,14 @@ public:
          it++) {
       CleanObsoleteElement()(*it);
     }
-    queue      = OwnPriorityQueue<T, std::vector<T>, CostCompare>();
+    queue = OwnPriorityQueue<T, std::vector<T>, CostCompare>();
     membership = std::set<T, FuncCompare>();
   }
 
   // clears the queue until a certain length is reached
   void update() {
     std::array<T, MAX_QUEUE_SIZE> tempQueue;
-    unsigned int                  length =
+    unsigned int length =
         std::min(static_cast<int>(queue.size() * QUEUE_COPY_LENGTH_PERCENTAGE),
                  MAX_QUEUE_COPY_LENGTH);
 
@@ -138,6 +138,6 @@ public:
 
 private:
   OwnPriorityQueue<T, std::vector<T>, CostCompare> queue;
-  std::set<T, FuncCompare>                         membership;
-  unsigned int                                     lastNodeCopied = 0;
+  std::set<T, FuncCompare> membership;
+  unsigned int lastNodeCopied = 0;
 };

--- a/include/heuristic/UniquePriorityQueue.hpp
+++ b/include/heuristic/UniquePriorityQueue.hpp
@@ -3,8 +3,10 @@
 // See README.md or go to https://github.com/cda-tum/qmap for more information.
 //
 
+#include <algorithm>
 #include <array>
 #include <cassert>
+#include <functional>
 #include <iostream>
 #include <queue>
 #include <set>
@@ -13,7 +15,6 @@
 #pragma once
 
 constexpr int MAX_QUEUE_SIZE = 6000000;
-constexpr int MAX_NODES_MARGIN = 500000;
 constexpr int MAX_QUEUE_COPY_LENGTH = 1000000;
 constexpr double QUEUE_COPY_LENGTH_PERCENTAGE = 1. / 6;
 

--- a/include/hybridmap/HardwareQubits.hpp
+++ b/include/hybridmap/HardwareQubits.hpp
@@ -36,10 +36,10 @@ namespace na {
 class HardwareQubits {
 protected:
   const NeutralAtomArchitecture* arch;
-  qc::Permutation                hwToCoordIdx;
-  SymmetricMatrix<SwapDistance>  swapDistances;
-  std::map<HwQubit, HwQubits>    nearbyQubits;
-  qc::Permutation                initialHwPos;
+  qc::Permutation hwToCoordIdx;
+  SymmetricMatrix<SwapDistance> swapDistances;
+  std::map<HwQubit, HwQubits> nearbyQubits;
+  qc::Permutation initialHwPos;
 
   /**
    * @brief Initializes the swap distances between the hardware qubits for the
@@ -82,8 +82,8 @@ protected:
 public:
   // Constructors
   HardwareQubits(const NeutralAtomArchitecture& architecture,
-                 InitialCoordinateMapping       initialCoordinateMapping,
-                 uint32_t                       seed)
+                 InitialCoordinateMapping initialCoordinateMapping,
+                 uint32_t seed)
       : arch(&architecture), swapDistances(architecture.getNqubits()) {
     switch (initialCoordinateMapping) {
     case Trivial:

--- a/include/hybridmap/HybridAnimation.hpp
+++ b/include/hybridmap/HybridAnimation.hpp
@@ -18,43 +18,43 @@
 
 namespace na {
 class AnimationAtoms {
-  using axesId   = std::uint32_t;
+  using axesId = std::uint32_t;
   using marginId = std::uint32_t;
 
 protected:
-  uint32_t                  colorSlm    = 0;
-  uint32_t                  colorAod    = 1;
-  uint32_t                  colorLocal  = 2;
+  uint32_t colorSlm = 0;
+  uint32_t colorAod = 1;
+  uint32_t colorLocal = 2;
   [[maybe_unused]] uint32_t colorGlobal = 3;
-  uint32_t                  colorCz     = 4;
+  uint32_t colorCz = 4;
 
-  std::map<CoordIndex, HwQubit>                coordIdxToId;
+  std::map<CoordIndex, HwQubit> coordIdxToId;
   std::map<HwQubit, std::pair<qc::fp, qc::fp>> idToCoord;
-  std::map<HwQubit, uint32_t>                  axesIds;
-  std::map<HwQubit, uint32_t>                  marginIds;
-  uint32_t                                     axesIdCounter   = 0;
-  uint32_t                                     marginIdCounter = 0;
+  std::map<HwQubit, uint32_t> axesIds;
+  std::map<HwQubit, uint32_t> marginIds;
+  uint32_t axesIdCounter = 0;
+  uint32_t marginIdCounter = 0;
 
-  axesId   addAxis(HwQubit id);
-  void     removeAxis(HwQubit id) { axesIds.erase(id); }
+  axesId addAxis(HwQubit id);
+  void removeAxis(HwQubit id) { axesIds.erase(id); }
   marginId addMargin(HwQubit id);
-  void     removeMargin(HwQubit id) { marginIds.erase(id); }
+  void removeMargin(HwQubit id) { marginIds.erase(id); }
 
 public:
   AnimationAtoms(const std::map<HwQubit, HwQubit>& initHwPos,
-                 const NeutralAtomArchitecture&    arch);
+                 const NeutralAtomArchitecture& arch);
 
-  std::string        getInitString();
-  std::string        getEndString(qc::fp endTime);
+  std::string getInitString();
+  std::string getEndString(qc::fp endTime);
   static std::string createCsvLine(qc::fp startTime, HwQubit id, qc::fp x,
                                    qc::fp y, uint32_t size = 1,
                                    uint32_t color = 0, bool axes = false,
                                    axesId axId = 0, bool margin = false,
-                                   marginId marginId   = 0,
-                                   qc::fp   marginSize = 0);
-  std::string        createCsvOp(const std::unique_ptr<qc::Operation>& op,
-                                 qc::fp startTime, qc::fp endTime,
-                                 const NeutralAtomArchitecture& arch);
+                                   marginId marginId = 0,
+                                   qc::fp marginSize = 0);
+  std::string createCsvOp(const std::unique_ptr<qc::Operation>& op,
+                          qc::fp startTime, qc::fp endTime,
+                          const NeutralAtomArchitecture& arch);
 };
 
 } // namespace na

--- a/include/hybridmap/HybridNeutralAtomMapper.hpp
+++ b/include/hybridmap/HybridNeutralAtomMapper.hpp
@@ -33,14 +33,14 @@ namespace na {
  * @brief Struct to store the runtime parameters of the mapper.
  */
 struct MapperParameters {
-  qc::fp                   lookaheadWeightSwaps = 0.1;
-  qc::fp                   lookaheadWeightMoves = 0.1;
-  qc::fp                   decay                = 0.1;
-  qc::fp                   shuttlingTimeWeight  = 1;
-  qc::fp                   gateWeight           = 1;
-  qc::fp                   shuttlingWeight      = 1;
-  uint32_t                 seed                 = 0;
-  bool                     verbose              = false;
+  qc::fp lookaheadWeightSwaps = 0.1;
+  qc::fp lookaheadWeightMoves = 0.1;
+  qc::fp decay = 0.1;
+  qc::fp shuttlingTimeWeight = 1;
+  qc::fp gateWeight = 1;
+  qc::fp shuttlingWeight = 1;
+  uint32_t seed = 0;
+  bool verbose = false;
   InitialCoordinateMapping initialMapping = InitialCoordinateMapping::Trivial;
 };
 
@@ -251,10 +251,10 @@ protected:
    * @param gateCoords The coordinates of the gate to find the best position for
    * @return The best position for the given gate coordinates
    */
-  CoordIndices      getBestMovePos(const CoordIndices& gateCoords);
-  MultiQubitMovePos getMovePositionRec(MultiQubitMovePos   currentPos,
+  CoordIndices getBestMovePos(const CoordIndices& gateCoords);
+  MultiQubitMovePos getMovePositionRec(MultiQubitMovePos currentPos,
                                        const CoordIndices& gateCoords,
-                                       const size_t&       maxNMoves);
+                                       const size_t& maxNMoves);
   /**
    * @brief Returns possible move combinations to move the gate qubits to the
    * given position.
@@ -263,7 +263,7 @@ protected:
    * @return Possible move combinations to move the gate qubits to the given
    * position
    */
-  MoveCombs getMoveCombinationsToPosition(HwQubits&     gateQubits,
+  MoveCombs getMoveCombinationsToPosition(HwQubits& gateQubits,
                                           CoordIndices& position);
 
   // Multi-qubit gate based methods
@@ -286,7 +286,7 @@ protected:
    * @return The swaps needed to move the given qubits to the given multi-qubit
    */
   WeightedSwaps getExactSwapsToPosition(const qc::Operation* op,
-                                        HwQubits             position);
+                                        HwQubits position);
 
   // Cost function calculation
   /**
@@ -311,7 +311,7 @@ protected:
    * @param swap The swap gate to compute the cost for
    * @return The cost of the swap gate
    */
-  qc::fp swapCost(const Swap&                            swap,
+  qc::fp swapCost(const Swap& swap,
                   const std::pair<Swaps, WeightedSwaps>& swapsFront,
                   const std::pair<Swaps, WeightedSwaps>& swapsLookahead);
   /**
@@ -357,8 +357,8 @@ protected:
 public:
   // Constructors
   [[maybe_unused]] NeutralAtomMapper(const NeutralAtomMapper&) = delete;
-  NeutralAtomMapper& operator=(const NeutralAtomMapper&)       = delete;
-  NeutralAtomMapper(NeutralAtomMapper&&)                       = delete;
+  NeutralAtomMapper& operator=(const NeutralAtomMapper&) = delete;
+  NeutralAtomMapper(NeutralAtomMapper&&) = delete;
   explicit NeutralAtomMapper(const NeutralAtomArchitecture& architecture,
                              const MapperParameters& p = MapperParameters())
       : arch(architecture), mappedQc(architecture.getNpositions()),
@@ -367,7 +367,7 @@ public:
                                       parameters.seed) {
     // need at least on free coordinate to shuttle
     if (architecture.getNpositions() - architecture.getNqubits() < 1) {
-      this->parameters.gateWeight      = 1;
+      this->parameters.gateWeight = 1;
       this->parameters.shuttlingWeight = 0;
     }
   };
@@ -379,7 +379,7 @@ public:
   void setParameters(const MapperParameters& p) {
     this->parameters = p;
     if (arch.getNpositions() - arch.getNqubits() < 1) {
-      this->parameters.gateWeight      = 1;
+      this->parameters.gateWeight = 1;
       this->parameters.shuttlingWeight = 0;
     }
     this->reset();
@@ -420,7 +420,7 @@ public:
    * operations
    */
   qc::QuantumComputation map(qc::QuantumComputation& qc,
-                             InitialMapping          initialMapping);
+                             InitialMapping initialMapping);
 
   /**
    * @brief Maps the given quantum circuit to the given architecture and
@@ -430,8 +430,8 @@ public:
    * hardware qubits
    */
   [[maybe_unused]] void mapAndConvert(qc::QuantumComputation& qc,
-                                      InitialMapping          initialMapping,
-                                      bool                    printInfo) {
+                                      InitialMapping initialMapping,
+                                      bool printInfo) {
     this->parameters.verbose = printInfo;
     map(qc, initialMapping);
     convertToAod(this->mappedQc);

--- a/include/hybridmap/MoveToAodConverter.hpp
+++ b/include/hybridmap/MoveToAodConverter.hpp
@@ -71,7 +71,7 @@ protected:
       // first: x, second: delta x, third: offset x
       std::vector<std::shared_ptr<AodMove>> activateXs;
       std::vector<std::shared_ptr<AodMove>> activateYs;
-      std::vector<AtomMove>                 moves;
+      std::vector<AtomMove> moves;
 
       AodActivation(const AodMove& activateX, const AodMove& activateY,
                     const AtomMove& move)
@@ -101,16 +101,16 @@ protected:
     // AODScheduler
     // NeutralAtomArchitecture to call necessary hardware information
     const NeutralAtomArchitecture& arch;
-    std::vector<AodActivation>     allActivations;
+    std::vector<AodActivation> allActivations;
     // Differentiate between loading and unloading
     qc::OpType type;
 
     // Constructor
-    AodActivationHelper()                           = delete;
+    AodActivationHelper() = delete;
     AodActivationHelper(const AodActivationHelper&) = delete;
-    AodActivationHelper(AodActivationHelper&&)      = delete;
+    AodActivationHelper(AodActivationHelper&&) = delete;
     AodActivationHelper(const NeutralAtomArchitecture& architecture,
-                        qc::OpType                     opType)
+                        qc::OpType opType)
         : arch(architecture), type(opType) {}
 
     // Methods
@@ -155,7 +155,7 @@ protected:
      * @param sign The direction of the offset moves (right/left or down/up)
      */
     static void reAssignOffsets(std::vector<std::shared_ptr<AodMove>>& aodMoves,
-                                int32_t                                sign);
+                                int32_t sign);
 
     /**
      * @brief Returns the maximum offset in the given dimension/direction from
@@ -177,8 +177,8 @@ protected:
      * @return True if there is still space, false otherwise
      */
     [[nodiscard]] bool checkIntermediateSpaceAtInit(Dimension dim,
-                                                    uint32_t  init,
-                                                    int32_t   sign) const;
+                                                    uint32_t init,
+                                                    int32_t sign) const;
 
     // Convert activation to AOD operations
     /**
@@ -216,10 +216,10 @@ protected:
     // the moves and the index they appear in the original quantum circuit (to
     // insert them back later)
     std::vector<std::pair<AtomMove, uint32_t>> moves;
-    std::vector<AodOperation>                  processedOpsInit;
-    std::vector<AodOperation>                  processedOpsFinal;
-    AodOperation                               processedOpShuttle;
-    std::vector<CoordIndex>                    qubitsUsedByGates;
+    std::vector<AodOperation> processedOpsInit;
+    std::vector<AodOperation> processedOpsFinal;
+    AodOperation processedOpShuttle;
+    std::vector<CoordIndex> qubitsUsedByGates;
 
     // Constructor
     explicit MoveGroup() = default;
@@ -265,8 +265,8 @@ protected:
   };
 
   const NeutralAtomArchitecture& arch;
-  qc::QuantumComputation         qcScheduled;
-  std::vector<MoveGroup>         moveGroups;
+  qc::QuantumComputation qcScheduled;
+  std::vector<MoveGroup> moveGroups;
 
   /**
    * @brief Assigns move operations into groups that can be executed in parallel
@@ -284,9 +284,9 @@ protected:
   void processMoveGroups();
 
 public:
-  MoveToAodConverter()                          = delete;
+  MoveToAodConverter() = delete;
   MoveToAodConverter(const MoveToAodConverter&) = delete;
-  MoveToAodConverter(MoveToAodConverter&&)      = delete;
+  MoveToAodConverter(MoveToAodConverter&&) = delete;
   explicit MoveToAodConverter(const NeutralAtomArchitecture& archArg)
       : arch(archArg), qcScheduled(arch.getNpositions()) {}
 

--- a/include/hybridmap/NeutralAtomArchitecture.hpp
+++ b/include/hybridmap/NeutralAtomArchitecture.hpp
@@ -63,9 +63,9 @@ class NeutralAtomArchitecture {
     std::uint16_t nAods;
     std::uint16_t nAodIntermediateLevels;
     std::uint16_t nAodCoordinates;
-    qc::fp        interQubitDistance;
-    qc::fp        interactionRadius;
-    qc::fp        blockingFactor;
+    qc::fp interQubitDistance;
+    qc::fp interactionRadius;
+    qc::fp blockingFactor;
 
   public:
     Properties() = default;
@@ -133,20 +133,20 @@ class NeutralAtomArchitecture {
         return t1 * t2 / (t1 + t2);
       }
     };
-    CoordIndex                    nQubits;
+    CoordIndex nQubits;
     std::map<std::string, qc::fp> gateTimes;
     std::map<std::string, qc::fp> gateAverageFidelities;
-    std::map<qc::OpType, qc::fp>  shuttlingTimes;
-    std::map<qc::OpType, qc::fp>  shuttlingAverageFidelities;
-    DecoherenceTimes              decoherenceTimes;
+    std::map<qc::OpType, qc::fp> shuttlingTimes;
+    std::map<qc::OpType, qc::fp> shuttlingAverageFidelities;
+    DecoherenceTimes decoherenceTimes;
   };
 
 protected:
   Properties properties{};
   Parameters parameters;
 
-  std::vector<Point>                coordinates;
-  SymmetricMatrix<SwapDistance>     swapDistances;
+  std::vector<Point> coordinates;
+  SymmetricMatrix<SwapDistance> swapDistances;
   std::vector<std::set<CoordIndex>> nearbyCoordinates;
 
   /**

--- a/include/hybridmap/NeutralAtomDefinitions.hpp
+++ b/include/hybridmap/NeutralAtomDefinitions.hpp
@@ -15,21 +15,21 @@
 namespace na {
 // A CoordIndex corresponds to node in the SLM grid, where an atom can be placed
 // (or not).
-using CoordIndex   = std::uint32_t;
+using CoordIndex = std::uint32_t;
 using CoordIndices = std::vector<CoordIndex>;
 // A HwQubit corresponds to an atom in the neutral atom architecture. It can be
 // used as qubit or not and occupies a certain position in the architecture.
-using HwQubit                      = uint32_t;
-using HwQubits                     = std::set<HwQubit>;
+using HwQubit = uint32_t;
+using HwQubits = std::set<HwQubit>;
 using HwPositions [[maybe_unused]] = std::vector<HwQubits>;
 // A qc::Qubit corresponds to a qubit in the quantum circuit. It can be mapped
 // to a hardware qubit.
 using Qubits = std::set<qc::Qubit>;
 
 // Swaps are between hardware qc::Qubits (one of them can be unmapped).
-using Swap          = std::pair<HwQubit, HwQubit>;
-using Swaps         = std::vector<Swap>;
-using WeightedSwap  = std::pair<Swap, qc::fp>;
+using Swap = std::pair<HwQubit, HwQubit>;
+using Swaps = std::vector<Swap>;
+using WeightedSwap = std::pair<Swap, qc::fp>;
 using WeightedSwaps = std::vector<WeightedSwap>;
 // The distance between two hardware qubits using SWAP gates.
 using SwapDistance = int32_t;

--- a/include/hybridmap/NeutralAtomLayer.hpp
+++ b/include/hybridmap/NeutralAtomLayer.hpp
@@ -24,10 +24,10 @@ namespace na {
 
 class NeutralAtomLayer {
 protected:
-  qc::DAG               dag;
-  qc::DAGIterators      iterators;
-  GateList              gates;
-  GateList              mappedSingleQubitGates;
+  qc::DAG dag;
+  qc::DAGIterators iterators;
+  GateList gates;
+  GateList mappedSingleQubitGates;
   std::vector<GateList> candidates;
 
   /**
@@ -49,12 +49,12 @@ protected:
   void candidatesToGates(const std::set<qc::Qubit>& qubitsToUpdate);
 
   // Commutation checks
-  static bool commutesWithAtQubit(const GateList&      layer,
+  static bool commutesWithAtQubit(const GateList& layer,
                                   const qc::Operation* opPointer,
-                                  const qc::Qubit&     qubit);
+                                  const qc::Qubit& qubit);
   static bool commuteAtQubit(const qc::Operation* opPointer1,
                              const qc::Operation* opPointer2,
-                             const qc::Qubit&     qubit);
+                             const qc::Qubit& qubit);
 
 public:
   // Constructor

--- a/include/hybridmap/NeutralAtomScheduler.hpp
+++ b/include/hybridmap/NeutralAtomScheduler.hpp
@@ -25,10 +25,10 @@ namespace na {
  * @brief Struct to store the results of the scheduler
  */
 struct SchedulerResults {
-  qc::fp   totalExecutionTime;
-  qc::fp   totalIdleTime;
-  qc::fp   totalGateFidelities;
-  qc::fp   totalFidelities;
+  qc::fp totalExecutionTime;
+  qc::fp totalIdleTime;
+  qc::fp totalGateFidelities;
+  qc::fp totalFidelities;
   uint32_t nCZs = 0;
 
   SchedulerResults(qc::fp executionTime, qc::fp idleTime, qc::fp gateFidelities,
@@ -53,11 +53,11 @@ struct SchedulerResults {
   [[maybe_unused]] [[nodiscard]] std::unordered_map<std::string, qc::fp>
   toMap() const {
     std::unordered_map<std::string, qc::fp> result;
-    result["totalExecutionTime"]  = totalExecutionTime;
-    result["totalIdleTime"]       = totalIdleTime;
+    result["totalExecutionTime"] = totalExecutionTime;
+    result["totalIdleTime"] = totalIdleTime;
     result["totalGateFidelities"] = totalGateFidelities;
-    result["totalFidelities"]     = totalFidelities;
-    result["nCZs"]                = nCZs;
+    result["totalFidelities"] = totalFidelities;
+    result["nCZs"] = nCZs;
     return result;
   }
 };
@@ -72,14 +72,14 @@ struct SchedulerResults {
 class NeutralAtomScheduler {
 protected:
   const NeutralAtomArchitecture& arch;
-  std::string                    animationCsv;
-  std::string                    animationArchitectureCsv;
+  std::string animationCsv;
+  std::string animationArchitectureCsv;
 
 public:
   // Constructor
-  NeutralAtomScheduler()                            = delete;
+  NeutralAtomScheduler() = delete;
   NeutralAtomScheduler(const NeutralAtomScheduler&) = delete;
-  NeutralAtomScheduler(NeutralAtomScheduler&&)      = delete;
+  NeutralAtomScheduler(NeutralAtomScheduler&&) = delete;
   explicit NeutralAtomScheduler(const NeutralAtomArchitecture& architecture)
       : arch(architecture) {}
 
@@ -93,13 +93,13 @@ public:
    * @param verbose If true, prints additional information
    * @return SchedulerResults
    */
-  SchedulerResults schedule(const qc::QuantumComputation&     qc,
+  SchedulerResults schedule(const qc::QuantumComputation& qc,
                             const std::map<HwQubit, HwQubit>& initHwPos,
                             bool verbose, bool createAnimationCsv = false,
                             qc::fp shuttlingSpeedFactor = 1.0);
 
   std::string getAnimationCsv() { return animationCsv; }
-  void        saveAnimationCsv(const std::string& filename) {
+  void saveAnimationCsv(const std::string& filename) {
     // save animation
     std::ofstream file(filename);
     file << animationCsv;
@@ -114,11 +114,11 @@ public:
 
   // Helper Print functions
   static void printSchedulerResults(std::vector<qc::fp>& totalExecutionTimes,
-                                    qc::fp               totalIdleTime,
-                                    qc::fp               totalGateFidelities,
+                                    qc::fp totalIdleTime,
+                                    qc::fp totalGateFidelities,
                                     qc::fp totalFidelities, uint32_t nCZs);
   static void printTotalExecutionTimes(
-      std::vector<qc::fp>&                                totalExecutionTimes,
+      std::vector<qc::fp>& totalExecutionTimes,
       std::vector<std::deque<std::pair<qc::fp, qc::fp>>>& blockedQubitsTimes);
 };
 

--- a/include/hybridmap/NeutralAtomUtils.hpp
+++ b/include/hybridmap/NeutralAtomUtils.hpp
@@ -77,10 +77,10 @@ struct Direction {
  * @details Each move consists in a start and end coordinate and the direction.
  */
 struct MoveVector {
-  qc::fp    xStart;
-  qc::fp    yStart;
-  qc::fp    xEnd;
-  qc::fp    yEnd;
+  qc::fp xStart;
+  qc::fp yStart;
+  qc::fp xEnd;
+  qc::fp yEnd;
   Direction direction;
 
   MoveVector(qc::fp xstart, qc::fp ystart, qc::fp xend, qc::fp yend)
@@ -112,7 +112,7 @@ struct MoveVector {
  */
 struct MoveComb {
   std::vector<AtomMove> moves;
-  qc::fp                cost = std::numeric_limits<qc::fp>::max();
+  qc::fp cost = std::numeric_limits<qc::fp>::max();
 
   MoveComb(std::vector<AtomMove> mov, const qc::fp c)
       : moves(std::move(mov)), cost(c) {}
@@ -162,7 +162,7 @@ struct MoveComb {
     cost = std::numeric_limits<qc::fp>::max();
   }
   [[nodiscard]] size_t size() const { return moves.size(); }
-  [[nodiscard]] bool   empty() const { return moves.empty(); }
+  [[nodiscard]] bool empty() const { return moves.empty(); }
 };
 
 /**
@@ -175,14 +175,14 @@ struct MoveCombs {
   explicit MoveCombs(std::vector<MoveComb> combs)
       : moveCombs(std::move(combs)) {}
 
-  [[nodiscard]] bool   empty() const { return moveCombs.empty(); }
+  [[nodiscard]] bool empty() const { return moveCombs.empty(); }
   [[nodiscard]] size_t size() const { return moveCombs.size(); }
 
   // define iterators that iterate over the moveCombs vector
-  using iterator       = std::vector<MoveComb>::iterator;
+  using iterator = std::vector<MoveComb>::iterator;
   using const_iterator = std::vector<MoveComb>::const_iterator;
-  iterator                     begin() { return moveCombs.begin(); }
-  iterator                     end() { return moveCombs.end(); }
+  iterator begin() { return moveCombs.begin(); }
+  iterator end() { return moveCombs.end(); }
   [[nodiscard]] const_iterator begin() const { return moveCombs.cbegin(); }
   [[nodiscard]] const_iterator end() const { return moveCombs.cend(); }
 
@@ -210,7 +210,7 @@ struct MoveCombs {
  */
 struct MultiQubitMovePos {
   CoordIndices coords;
-  size_t       nMoves{0};
+  size_t nMoves{0};
 };
 
 } // namespace na

--- a/include/logicblocks/Encodings.hpp
+++ b/include/logicblocks/Encodings.hpp
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <set>
 #include <utility>
 #include <vector>
 

--- a/include/logicblocks/Encodings.hpp
+++ b/include/logicblocks/Encodings.hpp
@@ -18,14 +18,14 @@ struct NestedVar {
   explicit NestedVar(const LogicTerm& v) : var(v) {};
   NestedVar(const LogicTerm& v, std::vector<NestedVar> l)
       : var(v), list(std::move(l)) {}
-  LogicTerm              var = LogicTerm::noneTerm();
+  LogicTerm var = LogicTerm::noneTerm();
   std::vector<NestedVar> list;
 };
 
 struct WeightedVar {
   WeightedVar(const LogicTerm& v, const int w) : var(v), weight(w) {}
-  LogicTerm var    = LogicTerm::noneTerm();
-  int       weight = 0;
+  LogicTerm var = LogicTerm::noneTerm();
+  int weight = 0;
 };
 inline bool operator<(const WeightedVar& rhs, const WeightedVar& lhs) {
   return rhs.weight < lhs.weight;
@@ -38,8 +38,8 @@ enum class Type : uint8_t { Uninitialized, AuxVar, ProgramVar };
 struct SavedLit {
   SavedLit() : var(LogicTerm::noneTerm()) {}
   SavedLit(Type t, const LogicTerm& v) : type(t), var(v) {}
-  Type      type = Type::Uninitialized;
-  LogicTerm var  = LogicTerm::noneTerm();
+  Type type = Type::Uninitialized;
+  LogicTerm var = LogicTerm::noneTerm();
 };
 
 LogicTerm atMostOneCmdr(const std::vector<NestedVar>& subords,
@@ -55,12 +55,12 @@ LogicTerm naiveAtMostOne(const std::vector<LogicTerm>& clauseVars);
 LogicTerm naiveAtLeastOne(const std::vector<LogicTerm>& clauseVars);
 
 LogicTerm atMostOneBiMander(const std::vector<LogicTerm>& vars,
-                            LogicBlock*                   logic);
+                            LogicBlock* logic);
 
 std::vector<NestedVar> groupVars(const std::vector<LogicTerm>& vars,
-                                 std::size_t                   maxSize);
+                                 std::size_t maxSize);
 std::vector<NestedVar> groupVarsAux(const std::vector<NestedVar>& vars,
-                                    std::size_t                   maxSize);
+                                    std::size_t maxSize);
 
 std::vector<std::vector<LogicTerm>>
 groupVarsBimander(const std::vector<LogicTerm>& vars, std::size_t groupCount);

--- a/include/logicblocks/Logic.hpp
+++ b/include/logicblocks/Logic.hpp
@@ -2,21 +2,15 @@
 
 #include <cassert>
 #include <cstdarg>
-#include <cstddef>
 #include <cstdint>
-#include <iostream>
-#include <limits>
-#include <memory>
-#include <ostream>
 #include <stdexcept>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 namespace logicbase {
 
-enum class Result { SAT, UNSAT, NDEF };
-enum class OpType {
+enum class Result : std::uint8_t { SAT, UNSAT, NDEF };
+enum class OpType : std::uint8_t {
   None,
   Constant,
   Variable,
@@ -44,7 +38,7 @@ enum class OpType {
   BitXor
 };
 
-enum class CType {
+enum class CType : std::uint8_t {
   BOOL,
   INT,
   REAL,

--- a/include/logicblocks/Logic.hpp
+++ b/include/logicblocks/Logic.hpp
@@ -272,16 +272,16 @@ inline CType getResultCType(OpType op) {
 
 class LogicTerm;
 
-using LogicVector   = std::vector<LogicTerm>;
-using LogicMatrix   = std::vector<LogicVector>;
+using LogicVector = std::vector<LogicTerm>;
+using LogicMatrix = std::vector<LogicVector>;
 using LogicMatrix3D = std::vector<LogicMatrix>;
 using LogicMatrix4D = std::vector<LogicMatrix3D>;
 
 class Logic {
 public:
-  virtual ~Logic()             = default;
+  virtual ~Logic() = default;
   virtual uint64_t getNextId() = 0;
-  virtual uint64_t getId()     = 0;
+  virtual uint64_t getId() = 0;
 };
 
 } // namespace logicbase

--- a/include/logicblocks/LogicBlock.hpp
+++ b/include/logicblocks/LogicBlock.hpp
@@ -4,7 +4,6 @@
 #include "LogicTerm.hpp"
 
 #include <cstdint>
-#include <iostream>
 #include <set>
 #include <string>
 #include <utility>
@@ -15,7 +14,7 @@ class Model;
 
 class LogicBlock : public Logic {
 protected:
-  std::set<LogicTerm, TermDepthComparator> clauses{};
+  std::set<LogicTerm, TermDepthComparator> clauses;
   Model* model{};
   bool convertWhenAssert;
   virtual void internalReset() = 0;

--- a/include/logicblocks/LogicBlock.hpp
+++ b/include/logicblocks/LogicBlock.hpp
@@ -16,10 +16,10 @@ class Model;
 class LogicBlock : public Logic {
 protected:
   std::set<LogicTerm, TermDepthComparator> clauses{};
-  Model*                                   model{};
-  bool                                     convertWhenAssert;
-  virtual void                             internalReset() = 0;
-  uint64_t                                 gid             = 0U;
+  Model* model{};
+  bool convertWhenAssert;
+  virtual void internalReset() = 0;
+  uint64_t gid = 0U;
 
 public:
   explicit LogicBlock(bool convert = false) : convertWhenAssert(convert) {}
@@ -34,9 +34,9 @@ public:
   LogicTerm makeVariable(const std::string& name, CType type = CType::BOOL,
                          uint16_t bvSize = 32U);
 
-  virtual void   produceInstance() = 0;
-  virtual Result solve()           = 0;
-  virtual void   reset();
+  virtual void produceInstance() = 0;
+  virtual Result solve() = 0;
+  virtual void reset();
 
   virtual std::string dumpInternalSolver() { return ""; }
 };
@@ -47,11 +47,11 @@ protected:
 
 public:
   explicit LogicBlockOptimizer(bool convert) : LogicBlock(convert) {}
-  void         weightedTerm(const LogicTerm& a, double weight);
-  virtual bool makeMinimize()                  = 0;
-  virtual bool makeMaximize()                  = 0;
+  void weightedTerm(const LogicTerm& a, double weight);
+  virtual bool makeMinimize() = 0;
+  virtual bool makeMaximize() = 0;
   virtual bool maximize(const LogicTerm& term) = 0;
   virtual bool minimize(const LogicTerm& term) = 0;
-  void         reset() override;
+  void reset() override;
 };
 } // namespace logicbase

--- a/include/logicblocks/LogicTerm.hpp
+++ b/include/logicblocks/LogicTerm.hpp
@@ -15,7 +15,7 @@ private:
   Logic* lb = nullptr;
   uint64_t id = 0;
   uint64_t depth = 0U;
-  std::string name{};
+  std::string name;
 
   OpType opType = OpType::Variable;
   bool value = false;
@@ -23,7 +23,7 @@ private:
   double fValue = 0.;
   uint64_t bvValue = 0U;
   uint16_t bvSize = 0;
-  std::vector<LogicTerm> nodes{};
+  std::vector<LogicTerm> nodes;
   CType cType = CType::BOOL;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/include/logicblocks/LogicTerm.hpp
+++ b/include/logicblocks/LogicTerm.hpp
@@ -12,19 +12,19 @@
 namespace logicbase {
 class LogicTerm {
 private:
-  Logic*      lb    = nullptr;
-  uint64_t    id    = 0;
-  uint64_t    depth = 0U;
+  Logic* lb = nullptr;
+  uint64_t id = 0;
+  uint64_t depth = 0U;
   std::string name{};
 
-  OpType                 opType  = OpType::Variable;
-  bool                   value   = false;
-  int                    iValue  = 0;
-  double                 fValue  = 0.;
-  uint64_t               bvValue = 0U;
-  uint16_t               bvSize  = 0;
+  OpType opType = OpType::Variable;
+  bool value = false;
+  int iValue = 0;
+  double fValue = 0.;
+  uint64_t bvValue = 0U;
+  uint16_t bvSize = 0;
   std::vector<LogicTerm> nodes{};
-  CType                  cType = CType::BOOL;
+  CType cType = CType::BOOL;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static inline uint64_t gid = 1;
@@ -122,17 +122,17 @@ public:
 
   [[nodiscard]] bool isConst() const;
 
-  [[nodiscard]] uint64_t                      getID() const { return id; }
+  [[nodiscard]] uint64_t getID() const { return id; }
   [[nodiscard]] const std::vector<LogicTerm>& getNodes() const { return nodes; }
-  [[nodiscard]] OpType             getOpType() const { return opType; }
-  [[nodiscard]] CType              getCType() const { return cType; }
+  [[nodiscard]] OpType getOpType() const { return opType; }
+  [[nodiscard]] CType getCType() const { return cType; }
   [[nodiscard]] const std::string& getName() const { return name; }
-  [[nodiscard]] Logic*             getLogic() const { return lb; }
-  [[nodiscard]] uint64_t           getDepth() const { return depth; }
+  [[nodiscard]] Logic* getLogic() const { return lb; }
+  [[nodiscard]] uint64_t getDepth() const { return depth; }
 
-  [[nodiscard]] bool     getBoolValue() const;
-  [[nodiscard]] int      getIntValue() const;
-  [[nodiscard]] double   getFloatValue() const;
+  [[nodiscard]] bool getBoolValue() const;
+  [[nodiscard]] int getIntValue() const;
+  [[nodiscard]] double getFloatValue() const;
   [[nodiscard]] uint64_t getBitVectorValue() const;
   [[nodiscard]] uint16_t getBitVectorSize() const;
 
@@ -159,14 +159,14 @@ public:
                                                  OpType op, Logic* logic);
 
   [[nodiscard]] static LogicTerm negateTerm(const LogicTerm& term,
-                                            Logic*           logic);
+                                            Logic* logic);
 
   [[nodiscard]] LogicTerm getBoolConversion() const;
 
   [[nodiscard]] static CType getTargetCType(const LogicTerm& a,
                                             const LogicTerm& b, OpType op);
 
-  [[nodiscard]] static CType getTargetCType(CType            targetType,
+  [[nodiscard]] static CType getTargetCType(CType targetType,
                                             const LogicTerm& b);
 
   [[nodiscard]] static std::vector<LogicTerm>
@@ -182,7 +182,7 @@ public:
 
 struct TermHash {
   std::size_t operator()(const LogicTerm& t) const;
-  bool        operator()(const LogicTerm& t1, const LogicTerm& t2) const;
+  bool operator()(const LogicTerm& t1, const LogicTerm& t2) const;
 };
 
 struct TermDepthComparator {

--- a/include/logicblocks/Model.hpp
+++ b/include/logicblocks/Model.hpp
@@ -16,9 +16,9 @@ public:
   explicit Model(Result res) : result(res) {}
   virtual ~Model() = default;
 
-  virtual int      getIntValue(const LogicTerm& a, LogicBlock* lb)       = 0;
-  virtual bool     getBoolValue(const LogicTerm& a, LogicBlock* lb)      = 0;
-  virtual double   getRealValue(const LogicTerm& a, LogicBlock* lb)      = 0;
+  virtual int getIntValue(const LogicTerm& a, LogicBlock* lb) = 0;
+  virtual bool getBoolValue(const LogicTerm& a, LogicBlock* lb) = 0;
+  virtual double getRealValue(const LogicTerm& a, LogicBlock* lb) = 0;
   virtual uint64_t getBitvectorValue(const LogicTerm& a, LogicBlock* lb) = 0;
 };
 } // namespace logicbase

--- a/include/logicblocks/Z3Logic.hpp
+++ b/include/logicblocks/Z3Logic.hpp
@@ -25,7 +25,7 @@ protected:
       variables;
   std::unordered_map<LogicTerm, std::vector<std::pair<bool, z3::expr>>,
                      TermHash, TermHash>
-                               cache{};
+      cache{};
   std::shared_ptr<z3::context> ctx;
 
 public:
@@ -33,7 +33,7 @@ public:
       : ctx(std::move(context)) {}
   virtual ~Z3Base() = default;
 
-  z3::expr     convert(const LogicTerm& a, CType toType = CType::ERRORTYPE);
+  z3::expr convert(const LogicTerm& a, CType toType = CType::ERRORTYPE);
   z3::context& getContext() { return *ctx; }
 
   static z3::expr getExprTerm(uint64_t id, CType type, Z3Base* z3base);
@@ -48,7 +48,7 @@ public:
                            z3::expr (*op)(const z3::expr&, const z3::expr&),
                            CType toType);
   z3::expr convertOperator(const LogicTerm& a, z3::expr (*op)(const z3::expr&),
-                           CType            toType);
+                           CType toType);
   z3::expr convertOperator(const LogicTerm& a, const LogicTerm& b,
                            const LogicTerm& c,
                            z3::expr (*op)(const z3::expr&, const z3::expr&,
@@ -64,7 +64,7 @@ public:
 class Z3LogicBlock : public LogicBlock, public Z3Base {
 protected:
   std::shared_ptr<z3::solver> solver;
-  void                        internalReset() override;
+  void internalReset() override;
 
 public:
   Z3LogicBlock(std::shared_ptr<z3::context> context,
@@ -75,9 +75,9 @@ public:
     variables.clear();
     cache.clear();
   }
-  void        assertFormula(const LogicTerm& a) override;
-  void        produceInstance() override;
-  Result      solve() override;
+  void assertFormula(const LogicTerm& a) override;
+  void produceInstance() override;
+  Result solve() override;
   std::string dumpInternalSolver() override {
     std::stringstream ss;
     ss << (*solver);
@@ -95,10 +95,10 @@ public:
 class Z3LogicOptimizer : public LogicBlockOptimizer, public Z3Base {
 private:
   std::shared_ptr<z3::optimize> optimizer;
-  void                          internalReset() override;
+  void internalReset() override;
 
 public:
-  Z3LogicOptimizer(std::shared_ptr<z3::context>  context,
+  Z3LogicOptimizer(std::shared_ptr<z3::context> context,
                    std::shared_ptr<z3::optimize> opt, bool convert = true)
       : LogicBlockOptimizer(convert), Z3Base(std::move(context)),
         optimizer(std::move(opt)) {}
@@ -106,14 +106,14 @@ public:
     variables.clear();
     cache.clear();
   }
-  void   assertFormula(const LogicTerm& a) override;
-  void   produceInstance() override;
+  void assertFormula(const LogicTerm& a) override;
+  void produceInstance() override;
   Result solve() override;
 
-  bool        makeMinimize() override;
-  bool        makeMaximize() override;
-  bool        maximize(const LogicTerm& term) override;
-  bool        minimize(const LogicTerm& term) override;
+  bool makeMinimize() override;
+  bool makeMaximize() override;
+  bool maximize(const LogicTerm& term) override;
+  bool minimize(const LogicTerm& term) override;
   std::string dumpInternalSolver() override {
     std::stringstream ss;
     ss << (*optimizer);

--- a/include/logicblocks/Z3Logic.hpp
+++ b/include/logicblocks/Z3Logic.hpp
@@ -25,7 +25,7 @@ protected:
       variables;
   std::unordered_map<LogicTerm, std::vector<std::pair<bool, z3::expr>>,
                      TermHash, TermHash>
-      cache{};
+      cache;
   std::shared_ptr<z3::context> ctx;
 
 public:

--- a/include/logicblocks/Z3Model.hpp
+++ b/include/logicblocks/Z3Model.hpp
@@ -3,11 +3,11 @@
 #include "LogicBlock.hpp"
 #include "LogicTerm.hpp"
 #include "Model.hpp"
-#include "z3++.h"
 
 #include <cstdint>
 #include <memory>
 #include <utility>
+#include <z3++.h>
 
 namespace z3logic {
 

--- a/include/logicblocks/Z3Model.hpp
+++ b/include/logicblocks/Z3Model.hpp
@@ -15,15 +15,15 @@ using namespace logicbase;
 
 class Z3Model : public Model {
 protected:
-  std::shared_ptr<z3::model>   model;
+  std::shared_ptr<z3::model> model;
   std::shared_ptr<z3::context> ctx;
 
 public:
   Z3Model(std::shared_ptr<z3::context> context, std::shared_ptr<z3::model> mdl)
       : model(std::move(mdl)), ctx(std::move(context)) {}
-  int      getIntValue(const LogicTerm& a, LogicBlock* lb) override;
-  bool     getBoolValue(const LogicTerm& a, LogicBlock* lb) override;
-  double   getRealValue(const LogicTerm& a, LogicBlock* lb) override;
+  int getIntValue(const LogicTerm& a, LogicBlock* lb) override;
+  bool getBoolValue(const LogicTerm& a, LogicBlock* lb) override;
+  double getRealValue(const LogicTerm& a, LogicBlock* lb) override;
   uint64_t getBitvectorValue(const LogicTerm& a, LogicBlock* lb) override;
 };
 } // namespace z3logic

--- a/include/logicblocks/util_logicblock.hpp
+++ b/include/logicblocks/util_logicblock.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include "Logic.hpp"
 #include "LogicBlock.hpp"
 #include "Z3Logic.hpp"
 
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include <z3++.h>
 
 namespace logicutil {
 using namespace logicbase;
 
-enum class ParamType {
+enum class ParamType : std::uint8_t {
   STR,
   BOOL,
   DOUBLE,

--- a/include/logicblocks/util_logicblock.hpp
+++ b/include/logicblocks/util_logicblock.hpp
@@ -22,12 +22,12 @@ enum class ParamType {
 
 class Param {
 public:
-  ParamType   type;
+  ParamType type;
   std::string name;
   std::string strvalue;
-  bool        bvalue  = false;
-  double      dvalue  = 0.;
-  uint32_t    uivalue = 0;
+  bool bvalue = false;
+  double dvalue = 0.;
+  uint32_t uivalue = 0;
   Param(std::string n, std::string value)
       : type(ParamType::STR), name(std::move(n)), strvalue(std::move(value)) {}
 
@@ -83,8 +83,8 @@ inline void setZ3Params(z3::params& p, const Params& params) {
 inline std::unique_ptr<LogicBlock>
 getZ3LogicBlock(bool& success, bool convertWhenAssert,
                 const Params& params = Params()) {
-  auto       c   = std::make_shared<z3::context>();
-  auto       slv = std::make_shared<z3::solver>(*c);
+  auto c = std::make_shared<z3::context>();
+  auto slv = std::make_shared<z3::solver>(*c);
   z3::params p(*c);
   setZ3Params(p, params);
   slv->set(p);
@@ -95,8 +95,8 @@ getZ3LogicBlock(bool& success, bool convertWhenAssert,
 inline std::unique_ptr<LogicBlockOptimizer>
 getZ3LogicOptimizer(bool& success, bool convertWhenAssert,
                     const Params& params = Params()) {
-  auto       c   = std::make_shared<z3::context>();
-  auto       opt = std::make_shared<z3::optimize>(*c);
+  auto c = std::make_shared<z3::context>();
+  auto opt = std::make_shared<z3::optimize>(*c);
   z3::params p(*c);
   setZ3Params(p, params);
   opt->set(p);

--- a/include/na/Architecture.hpp
+++ b/include/na/Architecture.hpp
@@ -91,7 +91,7 @@ public:
    * @details Times are in µs, fidelities are in [0,1].
    */
   struct OperationProperties {
-    Scope                    scope; // local or global
+    Scope scope;                    // local or global
     std::unordered_set<Zone> zones; // the zones where the gate can be applied
     Value time;     // the time the gate takes to be applied in µs
     Value fidelity; // the fidelity of the gate
@@ -103,26 +103,26 @@ public:
    * µm/µs.
    */
   struct ShuttlingProperties {
-    Index  rows          = 0; // maximum number of rows in one AOD
-    Index  cols          = 0; // maximum number of columns in one AOD
-    Number minX          = 0; // minimum x position of the AOD
-    Number maxX          = 0; // maximum x position of the AOD
-    Number minY          = 0; // minimum y position of the AOD
-    Number maxY          = 0; // maximum y position of the AOD
-    Value  speed         = 0; // speed of the AOD in µm/µs
-    Value  fidelity      = 1; // fidelity during the shuttling
-    Value  loadTime      = 0; // time to activate the AOD in µs
-    Value  loadFidelity  = 1; // fidelity of the load
-    Value  storeTime     = 0; // time to deactivate the AOD in µs
-    Value  storeFidelity = 1; // fidelity of the store
+    Index rows = 0;          // maximum number of rows in one AOD
+    Index cols = 0;          // maximum number of columns in one AOD
+    Number minX = 0;         // minimum x position of the AOD
+    Number maxX = 0;         // maximum x position of the AOD
+    Number minY = 0;         // minimum y position of the AOD
+    Number maxY = 0;         // maximum y position of the AOD
+    Value speed = 0;         // speed of the AOD in µm/µs
+    Value fidelity = 1;      // fidelity during the shuttling
+    Value loadTime = 0;      // time to activate the AOD in µs
+    Value loadFidelity = 1;  // fidelity of the load
+    Value storeTime = 0;     // time to deactivate the AOD in µs
+    Value storeFidelity = 1; // fidelity of the store
   };
   struct ZoneProperties {
-    std::string name;         // the name of the zone
-    Number      minX     = 0; // minimum x dimension
-    Number      maxX     = 0; // maximum x dimension
-    Number      minY     = 0; // minimum y dimension
-    Number      maxY     = 0; // maximum y dimension
-    Value       fidelity = 1; // fidelity during idling
+    std::string name;   // the name of the zone
+    Number minX = 0;    // minimum x dimension
+    Number maxX = 0;    // maximum x dimension
+    Number minY = 0;    // minimum y dimension
+    Number maxY = 0;    // maximum y dimension
+    Value fidelity = 1; // fidelity during idling
   };
 
 protected:
@@ -134,7 +134,7 @@ protected:
       gateSet; // all possible operations by their type, i.e. gate set
   DecoherenceTimes decoherenceTimes;          // the decoherence characteristic
   std::vector<ShuttlingProperties> shuttling; // all properties regarding AODs
-  Distance                         minAtomDistance =
+  Distance minAtomDistance =
       0; // minimal distance that must be kept between atoms
   Distance interactionRadius = 0; // the Rydberg radius
   Distance noInteractionRadius =
@@ -222,14 +222,14 @@ public:
   [[nodiscard]] auto isAllowedLocally(const FullOpType& t) const -> bool;
   /// Checks whether the gate can be applied (locally) in this zone.
   [[nodiscard]] auto isAllowedLocally(const FullOpType& t,
-                                      const Zone&       zone) const -> bool;
+                                      const Zone& zone) const -> bool;
   /// Checks whether the gate can be applied (locally) on this qubit.
   [[nodiscard]] auto isAllowedLocallyAt(const FullOpType& t,
-                                        const Point&      p) const -> bool;
+                                        const Point& p) const -> bool;
   /// Checks whether the gate is a global gate for this Zone.
   [[nodiscard]] auto isAllowedGlobally(const FullOpType& t) const -> bool;
   [[nodiscard]] auto isAllowedGlobally(const FullOpType& t,
-                                       const Zone&       zone) const -> bool;
+                                       const Zone& zone) const -> bool;
   [[nodiscard]] auto getNrowsInZone(const Zone& z) const -> Index;
   [[nodiscard]] auto
   getSitesInRow(const Zone& z, const Index& row) const -> std::vector<Index>;

--- a/include/na/Configuration.hpp
+++ b/include/na/Configuration.hpp
@@ -38,9 +38,9 @@ getMethodOfString(const std::string& method) -> NAMappingMethod {
 }
 class Configuration {
 private:
-  std::size_t     patchRows = 1;
-  std::size_t     patchCols = 1;
-  NAMappingMethod method    = NAMappingMethod::MaximizeParallelismHeuristic;
+  std::size_t patchRows = 1;
+  std::size_t patchCols = 1;
+  NAMappingMethod method = NAMappingMethod::MaximizeParallelismHeuristic;
 
 public:
   Configuration() = default;

--- a/include/na/Configuration.hpp
+++ b/include/na/Configuration.hpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <istream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 namespace na {

--- a/include/na/NAGraphAlgorithms.hpp
+++ b/include/na/NAGraphAlgorithms.hpp
@@ -20,8 +20,8 @@
 
 namespace na {
 
-using Color            = std::uint16_t;
-using Edge             = std::pair<qc::Qubit, qc::Qubit>;
+using Color = std::uint16_t;
+using Edge = std::pair<qc::Qubit, qc::Qubit>;
 using InteractionGraph = qc::Layer::InteractionGraph;
 
 class NAGraphAlgorithms {
@@ -48,7 +48,7 @@ public:
    * @return a set of edges with at least one node in vs
    */
   [[nodiscard]] static auto
-  coveredEdges(const InteractionGraph&              g,
+  coveredEdges(const InteractionGraph& g,
                const std::unordered_set<qc::Qubit>& vs)
       -> std::unordered_set<Edge, qc::PairHash<qc::Qubit, qc::Qubit>>;
 
@@ -87,10 +87,10 @@ public:
    */
   [[nodiscard]] static auto getLeastAdmissibleColor(
       const std::unordered_map<Edge, Color, qc::PairHash<qc::Qubit, qc::Qubit>>&
-                   coloring,
+          coloring,
       const Color& maxColor, const Edge& e, const qc::Qubit& v,
-      const std::vector<qc::Qubit>&                             sequence,
-      const qc::DirectedAcyclicGraph<qc::Qubit>&                partialOrder,
+      const std::vector<qc::Qubit>& sequence,
+      const qc::DirectedAcyclicGraph<qc::Qubit>& partialOrder,
       const std::unordered_map<std::pair<qc::Qubit, Color>, std::size_t,
                                qc::PairHash<qc::Qubit, Color>>& ranks) -> Color;
 
@@ -103,7 +103,7 @@ public:
    * @return a valid coloring of the edges
    */
   [[nodiscard]] static auto colorEdges(
-      const InteractionGraph&                                             g,
+      const InteractionGraph& g,
       const std::unordered_set<Edge, qc::PairHash<qc::Qubit, qc::Qubit>>& edges,
       const std::vector<qc::Qubit>& nodesQueue)
       -> std::pair<
@@ -133,7 +133,7 @@ public:
    * @return a new sequence with the vertices grouped by connected components
    */
   [[nodiscard]] static auto groupByConnectedComponent(
-      const InteractionGraph&       g,
+      const InteractionGraph& g,
       const std::vector<qc::Qubit>& sequence) -> std::vector<qc::Qubit>;
 
   /**
@@ -154,7 +154,7 @@ public:
    * vertices mapped to their relative x-position in every time step.
    */
   [[nodiscard]] static auto computeSequence(const InteractionGraph& g,
-                                            std::size_t             maxSites)
+                                            std::size_t maxSites)
       -> std::pair<std::vector<std::unordered_map<qc::Qubit, std::int64_t>>,
                    std::unordered_map<qc::Qubit, std::int64_t>>;
 };

--- a/include/na/NAMapper.hpp
+++ b/include/na/NAMapper.hpp
@@ -30,15 +30,15 @@ namespace na {
 class NAMapper {
 public:
   struct Statistics {
-    std::size_t               numInitialGates    = 0;
-    std::size_t               numEntanglingGates = 0;
-    std::size_t               initialDepth       = 0;
-    std::size_t               numMappedGates     = 0;
-    std::size_t               numQubits          = 0;
-    std::size_t               maxSeqWidth        = 0;
-    qc::fp                    preprocessTime     = 0.0; // [ms]
-    qc::fp                    mappingTime        = 0.0; // [ms]
-    qc::fp                    postprocessTime    = 0.0; // [ms]
+    std::size_t numInitialGates = 0;
+    std::size_t numEntanglingGates = 0;
+    std::size_t initialDepth = 0;
+    std::size_t numMappedGates = 0;
+    std::size_t numQubits = 0;
+    std::size_t maxSeqWidth = 0;
+    qc::fp preprocessTime = 0.0;  // [ms]
+    qc::fp mappingTime = 0.0;     // [ms]
+    qc::fp postprocessTime = 0.0; // [ms]
     [[nodiscard]] static auto header() -> std::string {
       return "numInitialGates,numEntanglingGates,initialDepth,numMappedGates,"
              "numQubits,maxSeqWidth,preprocessTime,mappingTime,"
@@ -52,7 +52,7 @@ public:
          << postprocessTime << '\n';
       return ss.str();
     }
-    friend auto operator<<(std::ostream&     os,
+    friend auto operator<<(std::ostream& os,
                            const Statistics& s) -> std::ostream& {
       return os << s.toString();
     }
@@ -60,20 +60,20 @@ public:
 
 protected:
   qc::QuantumComputation initialQc;
-  NAComputation          mappedQc;
-  Architecture           initialArch;
-  Architecture           arch;
-  Configuration          config;
-  Statistics             stats{};
-  bool                   done = false;
+  NAComputation mappedQc;
+  Architecture initialArch;
+  Architecture arch;
+  Configuration config;
+  Statistics stats{};
+  bool done = false;
 
   class Atom {
   public:
     enum class PositionStatus : std::uint8_t { UNDEFINED, DEFINED };
-    PositionStatus         positionStatus  = PositionStatus::UNDEFINED;
+    PositionStatus positionStatus = PositionStatus::UNDEFINED;
     std::shared_ptr<Point> initialPosition = std::make_shared<Point>(0, 0);
     std::shared_ptr<Point> currentPosition = initialPosition;
-    std::vector<Zone>      zones;
+    std::vector<Zone> zones;
     explicit Atom(const std::vector<Zone>& z = {}) : zones(z) {};
   };
   auto preprocess() -> void { validateCircuit(); }
@@ -85,14 +85,14 @@ protected:
   auto makeLogicalArrays() -> void;
   auto calculateMovements() -> void;
   [[nodiscard]] auto
-       checkApplicability(const qc::Operation*     op,
-                          const std::vector<Atom>& placement) const -> bool;
+  checkApplicability(const qc::Operation* op,
+                     const std::vector<Atom>& placement) const -> bool;
   auto updatePlacement(const qc::Operation* op,
-                       std::vector<Atom>&   placement) const -> void;
+                       std::vector<Atom>& placement) const -> void;
   [[nodiscard]] static auto
-  getMisplacement(const std::vector<Atom>&      initial,
+  getMisplacement(const std::vector<Atom>& initial,
                   const std::vector<qc::Qubit>& target,
-                  const qc::Qubit&              q) -> std::int64_t;
+                  const qc::Qubit& q) -> std::int64_t;
   /**
    * @brief Move atoms from the entangling zone to the destination zone.
    * @param initialFreeSites The sites that are not yet occupied from the start
@@ -122,15 +122,15 @@ protected:
   auto pickUp(std::vector<bool>& initialFreeSites,
               std::vector<bool>& currentFreeSites, std::vector<Atom>& placement,
               std::unordered_set<qc::Qubit>& currentlyShuttling,
-              const std::vector<qc::Qubit>&  qubits) -> void;
+              const std::vector<qc::Qubit>& qubits) -> void;
 
 public:
-  explicit NAMapper(Architecture         architecture,
+  explicit NAMapper(Architecture architecture,
                     const Configuration& configuration)
       : initialArch(std::move(architecture)),
         arch(initialArch.withConfig(configuration)), config(configuration) {}
   virtual ~NAMapper() = default;
-  auto               map(const qc::QuantumComputation& qc) -> void;
+  auto map(const qc::QuantumComputation& qc) -> void;
   [[nodiscard]] auto getResult() const -> const NAComputation& {
     if (!done) {
       throw std::logic_error("No result available.");

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -19,8 +19,8 @@
 #include <utility>
 #include <vector>
 
-using Matrix      = std::vector<std::vector<double>>;
-using Edge        = std::pair<std::uint16_t, std::uint16_t>;
+using Matrix = std::vector<std::vector<double>>;
+using Edge = std::pair<std::uint16_t, std::uint16_t>;
 using CouplingMap = std::set<Edge>;
 using QubitSubset = std::set<std::uint16_t>;
 
@@ -35,7 +35,7 @@ struct Exchange {
   std::uint16_t first;
   std::uint16_t second;
   std::uint16_t middleAncilla;
-  qc::OpType    op;
+  qc::OpType op;
 };
 
 class QMAPException : public std::runtime_error {
@@ -96,9 +96,9 @@ public:
    * e.g. in the case of fidelity-aware distances or distances on
    * mixed bi/unidirectional architectures)
    */
-  static void buildEdgeSkipTable(const CouplingMap&   couplingMap,
+  static void buildEdgeSkipTable(const CouplingMap& couplingMap,
                                  std::vector<Matrix>& distanceTables,
-                                 const Matrix&        edgeWeights);
+                                 const Matrix& edgeWeights);
   /**
    * @brief builds a distance table containing the minimal costs for moving
    * logical qubits from one physical qubit to another (along the cheapest path)
@@ -113,9 +113,9 @@ public:
    * @param reversalCost cost for reversing an edge
    * @param edgeSkipDistanceTable target distance table
    */
-  static void buildSingleEdgeSkipTable(const Matrix&      distanceTable,
+  static void buildSingleEdgeSkipTable(const Matrix& distanceTable,
                                        const CouplingMap& couplingMap,
-                                       double             reversalCost,
+                                       double reversalCost,
                                        Matrix& edgeSkipDistanceTable);
 
 protected:
@@ -194,8 +194,8 @@ using filter_function = std::function<bool(const QubitSubset&)>;
 std::vector<QubitSubset> subsets(const QubitSubset& input, std::size_t size,
                                  const filter_function& filter = nullptr);
 
-void        parseLine(const std::string& line, char separator,
-                      const std::set<char>&     escapeChars,
-                      const std::set<char>&     ignoredChars,
-                      std::vector<std::string>& result);
+void parseLine(const std::string& line, char separator,
+               const std::set<char>& escapeChars,
+               const std::set<char>& ignoredChars,
+               std::vector<std::string>& result);
 CouplingMap getFullyConnectedMap(std::uint16_t nQubits);

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -35,9 +35,9 @@ void Architecture::loadCouplingMap(AvailableArchitecture architecture) {
 
 void Architecture::loadCouplingMap(const std::string& filename) {
   const std::size_t slash = filename.find_last_of('/');
-  const std::size_t dot   = filename.find_last_of('.');
-  name                    = filename.substr(slash + 1, dot - slash - 1);
-  auto ifs                = std::ifstream(filename);
+  const std::size_t dot = filename.find_last_of('.');
+  name = filename.substr(slash + 1, dot - slash - 1);
+  auto ifs = std::ifstream(filename);
   if (ifs.good()) {
     this->loadCouplingMap(ifs);
   } else {
@@ -50,8 +50,8 @@ void Architecture::loadCouplingMap(std::istream& is) {
   properties.clear();
   std::string line;
 
-  const auto  rNqubits = std::regex("([0-9]+)");
-  const auto  rEdge    = std::regex("([0-9]+) ([0-9]+)");
+  const auto rNqubits = std::regex("([0-9]+)");
+  const auto rEdge = std::regex("([0-9]+) ([0-9]+)");
   std::smatch m;
 
   // get number of qubits
@@ -79,7 +79,7 @@ void Architecture::loadCouplingMap(std::istream& is) {
 }
 
 void Architecture::loadCouplingMap(std::uint16_t nQ, const CouplingMap& cm) {
-  nqubits     = nQ;
+  nqubits = nQ;
   couplingMap = cm;
   properties.clear();
   name = "generic_" + std::to_string(nQ);
@@ -88,7 +88,7 @@ void Architecture::loadCouplingMap(std::uint16_t nQ, const CouplingMap& cm) {
 
 void Architecture::loadProperties(const std::string& filename) {
   const std::size_t slash = filename.find_last_of('/');
-  const std::size_t dot   = filename.find_last_of('.');
+  const std::size_t dot = filename.find_last_of('.');
   properties.setName(filename.substr(slash + 1, dot - slash - 1));
   if (!isArchitectureAvailable()) {
     name = properties.getName();
@@ -108,9 +108,9 @@ void Architecture::loadProperties(std::istream& is) {
   properties.clear();
 
   double averageCNOTFidelity = 0.0;
-  int    numCNOTFidelities   = 0;
+  int numCNOTFidelities = 0;
 
-  std::string      line;
+  std::string line;
   const std::regex regexDoubleFidelity = std::regex(
       R"(((\d+).?(\d+):\W*?(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)))");
   std::smatch sMatch;
@@ -177,7 +177,7 @@ void Architecture::loadProperties(const Properties& props) {
       }
     }
     nqubits = props.getNqubits();
-    name    = "generic_" + std::to_string(nqubits);
+    name = "generic_" + std::to_string(nqubits);
     createDistanceTable();
   }
   properties = props;
@@ -195,19 +195,19 @@ Architecture::Architecture(const std::uint16_t nQ, const CouplingMap& cm,
 }
 
 void Architecture::createDistanceTable() {
-  isBidirectional  = true;
+  isBidirectional = true;
   isUnidirectional = true;
   Matrix edgeWeights(nqubits, std::vector<double>(
                                   nqubits, std::numeric_limits<double>::max()));
   for (const auto& edge : couplingMap) {
     if (couplingMap.find({edge.second, edge.first}) == couplingMap.end()) {
       // unidirectional edge
-      isBidirectional                            = false;
+      isBidirectional = false;
       edgeWeights.at(edge.second).at(edge.first) = COST_UNIDIRECTIONAL_SWAP;
       edgeWeights.at(edge.first).at(edge.second) = COST_UNIDIRECTIONAL_SWAP;
     } else {
       // bidirectional edge
-      isUnidirectional                           = false;
+      isUnidirectional = false;
       edgeWeights.at(edge.first).at(edge.second) = COST_BIDIRECTIONAL_SWAP;
     }
   }
@@ -291,7 +291,7 @@ void Architecture::createFidelityTable() {
 
 std::uint64_t
 Architecture::minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
-                                   std::int64_t                limit) {
+                                   std::int64_t limit) {
   const bool tryToAbortEarly = (limit != -1);
 
   // consolidate used qubits
@@ -302,8 +302,8 @@ Architecture::minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
 
   // create map for goal permutation
   std::unordered_map<std::uint16_t, std::uint16_t> goalPermutation{};
-  std::uint16_t                                    count    = 0U;
-  bool                                             identity = true;
+  std::uint16_t count = 0U;
+  bool identity = true;
   for (const auto q : qubits) {
     goalPermutation.emplace(q, permutation.at(count));
     if (q != permutation.at(count)) {
@@ -381,7 +381,7 @@ Architecture::minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
 }
 
 void Architecture::minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
-                                        std::vector<Edge>&          swaps) {
+                                        std::vector<Edge>& swaps) {
   // consolidate used qubits
   QubitSubset qubits{};
   for (const auto& q : permutation) {
@@ -395,8 +395,8 @@ void Architecture::minimumNumberOfSwaps(std::vector<std::uint16_t>& permutation,
 
   // create map for goal permutation
   std::unordered_map<std::uint16_t, std::uint16_t> goalPermutation{};
-  std::uint16_t                                    count    = 0;
-  bool                                             identity = true;
+  std::uint16_t count = 0;
+  bool identity = true;
   for (const auto q : qubits) {
     goalPermutation.emplace(q, permutation.at(count));
     if (q != permutation.at(count)) {
@@ -482,11 +482,11 @@ Architecture::getCouplingLimit(const QubitSubset& qubitChoice) const {
   return findCouplingLimit(getCouplingMap(), getNqubits(), qubitChoice);
 }
 
-std::uint64_t Architecture::bfs(const std::uint16_t   start,
-                                const std::uint16_t   goal,
+std::uint64_t Architecture::bfs(const std::uint16_t start,
+                                const std::uint16_t goal,
                                 const std::set<Edge>& teleportations) const {
   std::queue<std::vector<int>> queue;
-  std::vector<int>             v;
+  std::vector<int> v;
   v.push_back(start);
   queue.push(v);
   std::vector<std::vector<int>> solutions;
@@ -552,11 +552,11 @@ std::uint64_t Architecture::bfs(const std::uint16_t   start,
   return (length - 2) * 7 + 4;
 }
 
-std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
+std::size_t Architecture::findCouplingLimit(const CouplingMap& cm,
                                             const std::uint16_t nQubits) {
   std::vector<std::unordered_set<std::uint16_t>> connections;
-  std::vector<std::uint16_t>                     d;
-  std::vector<bool>                              visited;
+  std::vector<std::uint16_t> d;
+  std::vector<bool> visited;
   connections.resize(nQubits);
   std::uint16_t maxSum = 0;
   for (const auto& edge : cm) {
@@ -580,12 +580,12 @@ std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
   return maxSum;
 }
 
-std::size_t Architecture::findCouplingLimit(const CouplingMap&  cm,
+std::size_t Architecture::findCouplingLimit(const CouplingMap& cm,
                                             const std::uint16_t nQubits,
-                                            const QubitSubset&  qubitChoice) {
+                                            const QubitSubset& qubitChoice) {
   std::vector<std::unordered_set<std::uint16_t>> connections;
-  std::vector<std::uint16_t>                     d;
-  std::vector<bool>                              visited;
+  std::vector<std::uint16_t> d;
+  std::vector<bool> visited;
   connections.resize(nQubits);
   std::uint16_t maxSum = 0;
   for (const auto& edge : cm) {
@@ -652,8 +652,8 @@ void Architecture::getHighestFidelityCouplingMap(
     return;
   }
 
-  double bestFidelity        = std::numeric_limits<double>::lowest();
-  auto   allConnectedSubsets = getAllConnectedSubsets(subsetSize);
+  double bestFidelity = std::numeric_limits<double>::lowest();
+  auto allConnectedSubsets = getAllConnectedSubsets(subsetSize);
 
   for (const auto& qubitChoice : allConnectedSubsets) {
     CouplingMap map{};
@@ -661,7 +661,7 @@ void Architecture::getHighestFidelityCouplingMap(
     const auto currentFidelity =
         getAverageArchitectureFidelity(map, qubitChoice, properties);
     if (currentFidelity > bestFidelity) {
-      reducedMap   = map;
+      reducedMap = map;
       bestFidelity = currentFidelity;
     }
   }
@@ -698,7 +698,7 @@ void Architecture::getReducedCouplingMaps(
   }
 }
 void Architecture::getReducedCouplingMap(const QubitSubset& qubitChoice,
-                                         CouplingMap&       reducedMap) const {
+                                         CouplingMap& reducedMap) const {
   reducedMap.clear();
   if (!isArchitectureAvailable()) {
     reducedMap =
@@ -716,7 +716,7 @@ void Architecture::getReducedCouplingMap(const QubitSubset& qubitChoice,
 double
 Architecture::getAverageArchitectureFidelity(const CouplingMap& cm,
                                              const QubitSubset& qubitChoice,
-                                             const Properties&  props) {
+                                             const Properties& props) {
   if (props.empty()) {
     return 0.0;
   }

--- a/src/DataLogger.cpp
+++ b/src/DataLogger.cpp
@@ -40,10 +40,10 @@ void DataLogger::logArchitecture() {
     return;
   }
   nlohmann::json json;
-  json["name"]         = architecture->getName();
-  json["nqubits"]      = architecture->getNqubits();
+  json["name"] = architecture->getName();
+  json["nqubits"] = architecture->getNqubits();
   json["coupling_map"] = architecture->getCouplingMap();
-  json["distances"]    = architecture->getDistanceTable();
+  json["distances"] = architecture->getDistanceTable();
   if (architecture->isFidelityAvailable()) {
     auto& fidelity = json["fidelity"];
     fidelity["single_qubit_fidelities"] =
@@ -54,7 +54,7 @@ void DataLogger::logArchitecture() {
     fidelity["two_qubit_fidelity_costs"] =
         architecture->getTwoQubitFidelityCosts();
     fidelity["swap_fidelity_costs"] = architecture->getSwapFidelityCosts();
-    fidelity["fidelity_distances"]  = architecture->getFidelityDistanceTables();
+    fidelity["fidelity_distances"] = architecture->getFidelityDistanceTables();
   }
   of << json.dump(2);
   of.close();
@@ -82,10 +82,10 @@ void DataLogger::logFinalizeLayer(
     const std::vector<std::uint16_t>& singleQubitMultiplicity,
     const std::map<std::pair<std::uint16_t, std::uint16_t>,
                    std::pair<std::uint16_t, std::uint16_t>>&
-                                                       twoQubitMultiplicity,
+        twoQubitMultiplicity,
     const std::array<std::int16_t, MAX_DEVICE_QUBITS>& initialLayout,
     std::size_t finalNodeId, double finalCostFixed, double finalCostHeur,
-    double                                             finalLookaheadPenalty,
+    double finalLookaheadPenalty,
     const std::array<std::int16_t, MAX_DEVICE_QUBITS>& finalLayout,
     const std::vector<Exchange>& finalSwaps, std::size_t finalSearchDepth) {
   if (deactivated) {
@@ -107,41 +107,41 @@ void DataLogger::logFinalizeLayer(
               << "layer_" << layerIndex << ".json" << std::endl;
     return;
   }
-  nlohmann::json    json;
+  nlohmann::json json;
   std::stringstream qasmStream;
   ops.dumpOpenQASM3(qasmStream, qregs, cregs);
   json["qasm"] = qasmStream.str();
   if (twoQubitMultiplicity.empty()) {
     json["two_qubit_multiplicity"] = nlohmann::json::array();
   } else {
-    auto&       twoMultJSON = json["two_qubit_multiplicity"];
-    std::size_t j           = 0;
+    auto& twoMultJSON = json["two_qubit_multiplicity"];
+    std::size_t j = 0;
     for (const auto& [qubits, multiplicity] : twoQubitMultiplicity) {
-      twoMultJSON[j]["q1"]       = qubits.first;
-      twoMultJSON[j]["q2"]       = qubits.second;
-      twoMultJSON[j]["forward"]  = multiplicity.first;
+      twoMultJSON[j]["q1"] = qubits.first;
+      twoMultJSON[j]["q2"] = qubits.second;
+      twoMultJSON[j]["forward"] = multiplicity.first;
       twoMultJSON[j]["backward"] = multiplicity.second;
       ++j;
     }
   }
   json["single_qubit_multiplicity"] = singleQubitMultiplicity;
-  auto& initialLayoutJSON           = json["initial_layout"];
+  auto& initialLayoutJSON = json["initial_layout"];
   for (std::size_t i = 0; i < nqubits; ++i) {
     initialLayoutJSON[i] = initialLayout.at(i);
   }
-  json["final_node_id"]           = finalNodeId;
-  json["final_cost_fixed"]        = finalCostFixed;
-  json["final_cost_heur"]         = finalCostHeur;
+  json["final_node_id"] = finalNodeId;
+  json["final_cost_fixed"] = finalCostFixed;
+  json["final_cost_heur"] = finalCostHeur;
   json["final_lookahead_penalty"] = finalLookaheadPenalty;
-  auto& finalLayoutJSON           = json["final_layout"];
+  auto& finalLayoutJSON = json["final_layout"];
   for (std::size_t i = 0; i < nqubits; ++i) {
     finalLayoutJSON[i] = finalLayout.at(i);
   }
   if (finalSwaps.empty()) {
     json["final_swaps"] = nlohmann::json::array();
   } else {
-    auto&       finalSwapsJSON = json["final_swaps"];
-    std::size_t i              = 0;
+    auto& finalSwapsJSON = json["final_swaps"];
+    std::size_t i = 0;
     for (const auto& swap : finalSwaps) {
       finalSwapsJSON[i][0] = swap.first;
       finalSwapsJSON[i][1] = swap.second;
@@ -242,9 +242,9 @@ void DataLogger::logMappingResult(MappingResults& result) {
   }
 
   // prepare json data
-  nlohmann::json json      = result.json();
-  auto&          stats     = json["statistics"];
-  auto&          benchmark = stats["benchmark"];
+  nlohmann::json json = result.json();
+  auto& stats = json["statistics"];
+  auto& benchmark = stats["benchmark"];
   for (std::size_t i = 0; i < result.layerHeuristicBenchmark.size(); ++i) {
     benchmark["layers"][i] = result.layerHeuristicBenchmark.at(i).json();
   }

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -15,12 +15,12 @@
 
 void Mapper::initResults() {
   countGates(qc, results.input);
-  results.input.name    = qc.getName();
-  results.input.qubits  = static_cast<std::uint16_t>(qc.getNqubits());
-  results.architecture  = architecture->getName();
-  results.output.name   = qc.getName() + "_mapped";
+  results.input.name = qc.getName();
+  results.input.qubits = static_cast<std::uint16_t>(qc.getNqubits());
+  results.architecture = architecture->getName();
+  results.output.name = qc.getName() + "_mapped";
   results.output.qubits = architecture->getNqubits();
-  results.output.gates  = std::numeric_limits<std::size_t>::max();
+  results.output.gates = std::numeric_limits<std::size_t>::max();
   qcMapped.addQubitRegister(architecture->getNqubits());
 }
 
@@ -57,7 +57,7 @@ void Mapper::processDisjointQubitLayer(
       layer = std::max(*lastLayer.at(*control), *lastLayer.at(target)) + 1;
     }
     lastLayer.at(*control) = layer;
-    lastLayer.at(target)   = layer;
+    lastLayer.at(target) = layer;
   }
 
   if (layers.size() <= layer) {
@@ -105,7 +105,7 @@ void Mapper::processDisjoint2qBlockLayer(
       }
     }
     lastLayer.at(*control) = layer;
-    lastLayer.at(target)   = layer;
+    lastLayer.at(target) = layer;
   }
 
   if (layers.size() <= layer) {
@@ -143,8 +143,8 @@ void Mapper::createLayers() {
                           "decomposed to the appropriate gate set!");
     }
 
-    const bool                   singleQubit = !gate->isControlled();
-    std::optional<std::uint16_t> control     = std::nullopt;
+    const bool singleQubit = !gate->isControlled();
+    std::optional<std::uint16_t> control = std::nullopt;
     if (!singleQubit) {
       control = static_cast<std::uint16_t>(
           qc.initialLayout.at((*gate->getControls().begin()).qubit));
@@ -286,12 +286,12 @@ void Mapper::splitLayer(std::size_t index, Architecture& arch) {
       singleQubitMultiplicities.at(index);
   const TwoQubitMultiplicity& twoQubitMultiplicity =
       twoQubitMultiplicities.at(index);
-  std::vector<Gate>       layer0{};
-  std::vector<Gate>       layer1{};
+  std::vector<Gate> layer0{};
+  std::vector<Gate> layer1{};
   SingleQubitMultiplicity singleQubitMultiplicity0(arch.getNqubits(), 0);
   SingleQubitMultiplicity singleQubitMultiplicity1(arch.getNqubits(), 0);
-  TwoQubitMultiplicity    twoQubitMultiplicity0{};
-  TwoQubitMultiplicity    twoQubitMultiplicity1{};
+  TwoQubitMultiplicity twoQubitMultiplicity0{};
+  TwoQubitMultiplicity twoQubitMultiplicity1{};
   std::set<std::uint16_t> activeQubits0{};
   std::set<std::uint16_t> activeQubits1QGates0{};
   std::set<std::uint16_t> activeQubits2QGates0{};
@@ -518,9 +518,9 @@ void Mapper::postMappingOptimizations(const Configuration& config) {
   qc::CircuitOptimizer::cancelCNOTs(qcMapped);
 }
 
-void Mapper::countGates(decltype(qcMapped.cbegin())      it,
+void Mapper::countGates(decltype(qcMapped.cbegin()) it,
                         const decltype(qcMapped.cend())& end,
-                        MappingResults::CircuitInfo&     info) {
+                        MappingResults::CircuitInfo& info) {
   for (; it != end; ++it) {
     const auto& g = *it;
     if (g->getType() == qc::Teleportation) {

--- a/src/Mapper.cpp
+++ b/src/Mapper.cpp
@@ -5,13 +5,25 @@
 
 #include "Mapper.hpp"
 
+#include "Architecture.hpp"
 #include "CircuitOptimizer.hpp"
 #include "Definitions.hpp"
+#include "configuration/Layering.hpp"
 #include "operations/CompoundOperation.hpp"
+#include "operations/OpType.hpp"
+#include "utils.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <set>
 #include <utility>
+#include <vector>
 
 void Mapper::initResults() {
   countGates(qc, results.input);

--- a/src/cliffordsynthesis/CliffordSynthesizer.cpp
+++ b/src/cliffordsynthesis/CliffordSynthesizer.cpp
@@ -6,17 +6,30 @@
 #include "cliffordsynthesis/CliffordSynthesizer.hpp"
 
 #include "QuantumComputation.hpp"
+#include "cliffordsynthesis/Configuration.hpp"
 #include "cliffordsynthesis/Tableau.hpp"
-#include "logicblocks/Logic.hpp"
-#include "plog/Appenders/ColorConsoleAppender.h"
-#include "plog/Formatters/TxtFormatter.h"
-#include "plog/Init.h"
-#include "plog/Log.h"
+#include "cliffordsynthesis/TargetMetric.hpp"
+#include "cliffordsynthesis/encoding/SATEncoder.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Operation.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <cstddef>
 #include <fstream>
 #include <future>
 #include <memory>
+#include <plog/Appenders/ConsoleAppender.h>
+#include <plog/Formatters/TxtFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+#include <plog/Logger.h>
+#include <plog/Severity.h>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace cs {
 

--- a/src/cliffordsynthesis/CliffordSynthesizer.cpp
+++ b/src/cliffordsynthesis/CliffordSynthesizer.cpp
@@ -35,15 +35,15 @@ void CliffordSynthesizer::synthesize(const Configuration& config) {
   const auto start = std::chrono::high_resolution_clock::now();
 
   // create the general configuration for the SAT encoder
-  auto encoderConfig                = EncoderConfig();
-  encoderConfig.initialTableau      = &initialTableau;
-  encoderConfig.targetTableau       = &targetTableau;
-  encoderConfig.nQubits             = initialTableau.getQubitCount();
-  encoderConfig.timestepLimit       = configuration.initialTimestepLimit;
-  encoderConfig.targetMetric        = configuration.target;
-  encoderConfig.useMaxSAT           = configuration.useMaxSAT;
+  auto encoderConfig = EncoderConfig();
+  encoderConfig.initialTableau = &initialTableau;
+  encoderConfig.targetTableau = &targetTableau;
+  encoderConfig.nQubits = initialTableau.getQubitCount();
+  encoderConfig.timestepLimit = configuration.initialTimestepLimit;
+  encoderConfig.targetMetric = configuration.target;
+  encoderConfig.useMaxSAT = configuration.useMaxSAT;
   encoderConfig.useSymmetryBreaking = configuration.useSymmetryBreaking;
-  encoderConfig.solverParameters    = configuration.solverParameters;
+  encoderConfig.solverParameters = configuration.solverParameters;
   encoderConfig.useMultiGateEncoding =
       requiresMultiGateEncoding(encoderConfig.targetMetric);
 
@@ -70,8 +70,8 @@ void CliffordSynthesizer::synthesize(const Configuration& config) {
 
   if (!configuration.linearSearch) {
     const auto [lowerBin, upperBin] = determineUpperBound(encoderConfig);
-    lower                           = lowerBin;
-    upper                           = upperBin;
+    lower = lowerBin;
+    upper = upperBin;
 
     // if the upper bound is 0, the solution does not require any gates and the
     // synthesis is done.
@@ -179,7 +179,7 @@ CliffordSynthesizer::determineUpperBound(EncoderConfig config) {
   return {lowerBound, upperBound};
 }
 
-void CliffordSynthesizer::gateOptimalSynthesis(EncoderConfig     config,
+void CliffordSynthesizer::gateOptimalSynthesis(EncoderConfig config,
                                                const std::size_t lower,
                                                const std::size_t upper) {
   // Gate-optimal synthesis is achieved by determining a timestep limit T such
@@ -253,10 +253,10 @@ void CliffordSynthesizer::minimizeGatesFixedDepth(EncoderConfig config) {
             << " and " << results.getGates()
             << " gate(s). Trying to minimize the number of gates.";
 
-  config.targetMetric         = TargetMetric::Gates;
-  config.timestepLimit        = results.getDepth();
+  config.targetMetric = TargetMetric::Gates;
+  config.timestepLimit = results.getDepth();
   config.useMultiGateEncoding = true;
-  config.useMaxSAT            = configuration.useMaxSAT;
+  config.useMaxSAT = configuration.useMaxSAT;
 
   if (config.useMaxSAT) {
     runMaxSAT(config);
@@ -328,11 +328,11 @@ void CliffordSynthesizer::minimizeTwoQubitGatesFixedGateCount(
             << results.getTwoQubitGates() << " two-qubit gates and at most "
             << gateCount << " gates.";
 
-  config.targetMetric         = TargetMetric::TwoQubitGates;
-  config.timestepLimit        = gateCount;
+  config.targetMetric = TargetMetric::TwoQubitGates;
+  config.timestepLimit = gateCount;
   config.useMultiGateEncoding = false;
-  config.useMaxSAT            = true;
-  config.twoQubitGateLimit    = results.getTwoQubitGates() - 1U;
+  config.useMaxSAT = true;
+  config.twoQubitGateLimit = results.getTwoQubitGates() - 1U;
 
   runMaxSAT(config);
 
@@ -356,11 +356,11 @@ void CliffordSynthesizer::minimizeGatesFixedTwoQubitGateCount(
             << results.getGates()
             << " gate(s) overall. Trying to minimize the number of gates.";
 
-  config.targetMetric         = TargetMetric::Gates;
-  config.timestepLimit        = results.getGates();
+  config.targetMetric = TargetMetric::Gates;
+  config.timestepLimit = results.getGates();
   config.useMultiGateEncoding = false;
-  config.useMaxSAT            = configuration.useMaxSAT;
-  config.twoQubitGateLimit    = results.getTwoQubitGates();
+  config.useMaxSAT = configuration.useMaxSAT;
+  config.twoQubitGateLimit = results.getTwoQubitGates();
 
   if (config.useMaxSAT) {
     runMaxSAT(config);
@@ -387,8 +387,8 @@ void CliffordSynthesizer::runMaxSAT(const EncoderConfig& config) {
 
 Results CliffordSynthesizer::callSolver(const EncoderConfig& config) {
   ++solverCalls;
-  auto       encoder = encoding::SATEncoder(config);
-  const auto res     = encoder.run();
+  auto encoder = encoding::SATEncoder(config);
+  const auto res = encoder.run();
   if (configuration.dumpIntermediateResults && res.sat()) {
     const auto filename = configuration.intermediateResultsPath +
                           "intermediate_" + std::to_string(solverCalls) +
@@ -402,8 +402,8 @@ Results CliffordSynthesizer::callSolver(const EncoderConfig& config) {
 }
 
 void CliffordSynthesizer::updateResults(const Configuration& config,
-                                        const Results&       newResults,
-                                        Results&             currentResults) {
+                                        const Results& newResults,
+                                        Results& currentResults) {
   if (!newResults.sat()) {
     return;
   }
@@ -455,8 +455,8 @@ std::vector<std::size_t> getLayers(const qc::QuantumComputation& qc) {
   std::vector<std::size_t> layerNum{};
   layerNum.resize(qc.size());
   std::vector<std::size_t> layers{};
-  std::size_t              layer = 0U;
-  std::size_t              i     = 0;
+  std::size_t layer = 0U;
+  std::size_t i = 0;
   for (const auto& gate : qc) {
     if (gate->isCompoundOperation()) {
       const auto* compOp = dynamic_cast<qc::CompoundOperation*>(gate.get());
@@ -480,19 +480,19 @@ void CliffordSynthesizer::depthHeuristicSynthesis() {
   if (initialCircuit->getDepth() == 0) {
     return;
   }
-  auto optimalConfig                 = configuration;
-  optimalConfig.heuristic            = false;
-  optimalConfig.target               = TargetMetric::Depth;
+  auto optimalConfig = configuration;
+  optimalConfig.heuristic = false;
+  optimalConfig.target = TargetMetric::Depth;
   optimalConfig.initialTimestepLimit = configuration.splitSize;
 
   qc::CircuitOptimizer::reorderOperations(*initialCircuit);
-  qc::QuantumComputation          optCircuit{initialCircuit->getNqubits()};
+  qc::QuantumComputation optCircuit{initialCircuit->getNqubits()};
   const std::vector<std::size_t>& layers = getLayers(*initialCircuit);
 
   std::vector<std::future<std::shared_ptr<qc::QuantumComputation>>> subCircuits;
   for (std::size_t i = 0; i < layers.size() - 1; i += configuration.splitSize) {
     std::size_t const startIdx = layers[i];
-    std::size_t       endIdx   = 0;
+    std::size_t endIdx = 0;
 
     if (i + configuration.splitSize >= layers.size()) {
       endIdx = layers.back();
@@ -523,7 +523,7 @@ std::shared_ptr<qc::QuantumComputation>
 CliffordSynthesizer::synthesizeSubcircuit(
     const std::shared_ptr<qc::QuantumComputation>& qc, std::size_t begin,
     std::size_t end, const Configuration& config) {
-  const Tableau       subTargetTableau{*qc, begin, end, true};
+  const Tableau subTargetTableau{*qc, begin, end, true};
   CliffordSynthesizer synth(subTargetTableau);
   synth.synthesize(config);
 

--- a/src/cliffordsynthesis/Tableau.cpp
+++ b/src/cliffordsynthesis/Tableau.cpp
@@ -5,18 +5,26 @@
 
 #include "cliffordsynthesis/Tableau.hpp"
 
+#include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
 #include "operations/OpType.hpp"
 #include "operations/Operation.hpp"
-#include "plog/Log.h"
 #include "utils.hpp"
 
+#include <algorithm>
+#include <cassert>
+#include <cctype>
 #include <cstddef>
 #include <fstream>
 #include <istream>
+#include <optional>
 #include <ostream>
+#include <plog/Log.h>
 #include <regex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace cs {

--- a/src/cliffordsynthesis/Tableau.cpp
+++ b/src/cliffordsynthesis/Tableau.cpp
@@ -45,9 +45,9 @@ void Tableau::import(const std::string& filename) {
 void Tableau::import(std::istream& is) {
   tableau.clear();
 
-  std::string              line;
+  std::string line;
   std::vector<std::string> data{};
-  char                     delimiter = '|';
+  char delimiter = '|';
 
   while (std::getline(is, line)) {
     if (line.find('|', 0) == std::string::npos) {
@@ -154,7 +154,7 @@ void Tableau::applyGate(const qc::Operation* const gate) {
 }
 
 void Tableau::createDiagonalTableau(const std::size_t nQ,
-                                    const bool        includeDestabilizers) {
+                                    const bool includeDestabilizers) {
   nQubits = nQ;
   tableau.clear();
   if (includeDestabilizers) {
@@ -200,7 +200,7 @@ std::string Tableau::toString() const {
 
 void Tableau::fromString(const std::string& str) {
   std::stringstream ss(str);
-  std::string       line;
+  std::string line;
   std::getline(ss, line);
   if (line.empty()) {
     return;
@@ -291,7 +291,7 @@ void Tableau::applyCX(const std::size_t control, const std::size_t target) {
     const auto zb = tableau[i][target + nQubits];
     tableau[i][2 * nQubits] ^= (xa & zb) & ((xb ^ za) ^ 1);
     tableau[i][control + nQubits] = za ^ zb;
-    tableau[i][target]            = xb ^ xa;
+    tableau[i][target] = xb ^ xa;
   }
 }
 
@@ -431,7 +431,7 @@ Tableau::RowType Tableau::parseStabilizer(const std::string& stab) {
 
 void Tableau::loadStabilizerDestabilizerString(const std::string& string) {
   std::stringstream ss(string);
-  std::string       line;
+  std::string line;
   std::getline(ss, line);
   if (line.empty()) {
     return;
@@ -450,7 +450,7 @@ void Tableau::loadStabilizerDestabilizerString(const std::string& string) {
   }
 
   std::optional<std::size_t> stabLength;
-  const auto&                checkStabLength = [&](const RowType& row) {
+  const auto& checkStabLength = [&](const RowType& row) {
     if (!stabLength.has_value()) {
       stabLength = row.size();
     }
@@ -459,11 +459,11 @@ void Tableau::loadStabilizerDestabilizerString(const std::string& string) {
     }
   };
 
-  const char  delimiter = ',';
+  const char delimiter = ',';
   std::string stab;
   for (std::size_t pos = stabilizers.find(delimiter); pos != std::string::npos;
-       pos             = stabilizers.find(delimiter)) {
-    stab            = stabilizers.substr(0, pos);
+       pos = stabilizers.find(delimiter)) {
+    stab = stabilizers.substr(0, pos);
     const auto& row = parseStabilizer(stab);
     checkStabLength(row);
     tableau.push_back(row);

--- a/src/cliffordsynthesis/encoding/GateEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/GateEncoder.cpp
@@ -67,7 +67,7 @@ void GateEncoder::Variables::collectTwoQubitGateVariables(
     const std::size_t pos, const std::size_t qubit, const bool target,
     LogicVector& variables) const {
   const auto& twoQubitGates = gC[pos];
-  const auto  n             = twoQubitGates.size();
+  const auto n = twoQubitGates.size();
   for (std::size_t q = 0; q < n; ++q) {
     if (q == qubit) {
       continue;
@@ -94,7 +94,7 @@ GateEncoder::collectGateTransformations(
 
   for (const auto& gate : SINGLE_QUBIT_GATES) {
     const auto& transformation = gateToTransformation(pos, qubit, gate);
-    const auto& it             = std::find_if(
+    const auto& it = std::find_if(
         transformations.begin(), transformations.end(), [&](const auto& entry) {
           return entry.first.deepEquals(transformation);
         });
@@ -165,7 +165,7 @@ void GateEncoder::assertRConstraints(const std::size_t pos,
 
 void GateEncoder::extractCircuitFromModel(Results& res, Model& model) {
   std::size_t nSingleQubitGates = 0U;
-  std::size_t nTwoQubitGates    = 0U;
+  std::size_t nTwoQubitGates = 0U;
 
   qc::QuantumComputation qc(N);
   for (std::size_t t = 0; t < T; ++t) {
@@ -198,8 +198,8 @@ void GateEncoder::extractSingleQubitGatesFromModel(
   }
 }
 
-void GateEncoder::extractTwoQubitGatesFromModel(const std::size_t       pos,
-                                                Model&                  model,
+void GateEncoder::extractTwoQubitGatesFromModel(const std::size_t pos,
+                                                Model& model,
                                                 qc::QuantumComputation& qc,
                                                 size_t& nTwoQubitGates) {
   const auto& twoQubitGates = vars.gC[pos];
@@ -235,7 +235,7 @@ void GateEncoder::assertSingleQubitGateCancellationConstraints(
   }
 
   // gate variables of the current and the next timestep
-  const auto& gSNow  = vars.gS[pos];
+  const auto& gSNow = vars.gS[pos];
   const auto& gSNext = vars.gS[pos + 1U];
 
   // Any Pauli must not be followed by another Pauli since -iXYZ = I.
@@ -251,21 +251,21 @@ void GateEncoder::assertSingleQubitGateCancellationConstraints(
   }
   constexpr bool containsPaulis = containsX() || containsY() || containsZ();
   if constexpr (containsPaulis) {
-    auto gates      = gSNow[gateToIndex(paulis[0])][qubit];
+    auto gates = gSNow[gateToIndex(paulis[0])][qubit];
     auto disallowed = !gSNext[gateToIndex(paulis[0])][qubit];
     for (std::size_t i = 1U; i < paulis.size(); ++i) {
-      gates      = gates || gSNow[gateToIndex(paulis[i])][qubit];
+      gates = gates || gSNow[gateToIndex(paulis[i])][qubit];
       disallowed = disallowed && !gSNext[gateToIndex(paulis[i])][qubit];
     }
 
     if constexpr (containsH()) {
       // -(X|Y|Z)-H- ~= -H-(Z|Y|X)-
       constexpr auto gateIndex = gateToIndex(qc::OpType::H);
-      disallowed               = disallowed && !gSNext[gateIndex][qubit];
+      disallowed = disallowed && !gSNext[gateIndex][qubit];
     }
 
     if constexpr (containsS() && containsSdag()) {
-      const auto gateIndexS   = gateToIndex(qc::OpType::S);
+      const auto gateIndexS = gateToIndex(qc::OpType::S);
       const auto gateIndexSdg = gateToIndex(qc::OpType::Sdg);
 
       // -X-(S|Sd)- ~= -(Sd|S)-X-
@@ -292,7 +292,7 @@ void GateEncoder::assertSingleQubitGateCancellationConstraints(
       constexpr auto gateIndexZ = gateToIndex(qc::OpType::Z);
 
       // -S-S- = -Z-
-      auto gates      = gSNow[gateIndexS][qubit];
+      auto gates = gSNow[gateIndexS][qubit];
       auto disallowed = !gSNext[gateIndexS][qubit];
 
       if constexpr (containsSdag()) {
@@ -303,7 +303,7 @@ void GateEncoder::assertSingleQubitGateCancellationConstraints(
         // -Sd-Z-  = -S-
         // -S-Sd-  = -I-
         // -S-Z-   = -Sd-
-        gates      = gates || gSNow[gateIndexSdag][qubit];
+        gates = gates || gSNow[gateIndexSdag][qubit];
         disallowed = disallowed && !gSNext[gateIndexSdag][qubit] &&
                      !gSNext[gateIndexZ][qubit];
       }

--- a/src/cliffordsynthesis/encoding/GateEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/GateEncoder.cpp
@@ -6,10 +6,20 @@
 #include "cliffordsynthesis/encoding/GateEncoder.hpp"
 
 #include "Definitions.hpp"
+#include "Logic.hpp"
+#include "LogicTerm.hpp"
+#include "QuantumComputation.hpp"
+#include "cliffordsynthesis/Results.hpp"
 #include "logicblocks/Encodings.hpp"
 #include "logicblocks/Model.hpp"
+#include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
-#include "plog/Log.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <plog/Log.h>
+#include <string>
+#include <vector>
 
 namespace cs::encoding {
 

--- a/src/cliffordsynthesis/encoding/MultiGateEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/MultiGateEncoder.cpp
@@ -5,8 +5,15 @@
 
 #include "cliffordsynthesis/encoding/MultiGateEncoder.hpp"
 
+#include "Logic.hpp"
 #include "logicblocks/LogicTerm.hpp"
-#include "plog/Log.h"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <plog/Log.h>
+#include <plog/Severity.h>
+#include <string>
 
 namespace cs::encoding {
 

--- a/src/cliffordsynthesis/encoding/MultiGateEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/MultiGateEncoder.cpp
@@ -86,7 +86,7 @@ void encoding::MultiGateEncoder::assertTwoQubitGateConstraints(
 
 LogicTerm encoding::MultiGateEncoder::createTwoQubitGateConstraint(
     std::size_t pos, std::size_t ctrl, std::size_t trgt) {
-  auto changes              = LogicTerm(true);
+  auto changes = LogicTerm(true);
   const auto [xCtrl, xTrgt] = tvars->twoQubitXChange(pos, ctrl, trgt);
   const auto [zCtrl, zTrgt] = tvars->twoQubitZChange(pos, ctrl, trgt);
 
@@ -110,7 +110,7 @@ void MultiGateEncoder::assertSingleQubitGateOrderConstraints(
   }
 
   // gate variables of the current and the next time step
-  const auto& gSNow  = vars.gS[pos];
+  const auto& gSNow = vars.gS[pos];
   const auto& gSNext = vars.gS[pos + 1];
 
   // once no gate is applied to the considered qubit, no single qubit gate can
@@ -134,7 +134,7 @@ void MultiGateEncoder::assertTwoQubitGateOrderConstraints(
   }
 
   // gate variables of the current and the next time step
-  const auto& gSNow  = vars.gS[pos];
+  const auto& gSNow = vars.gS[pos];
   const auto& gCNext = vars.gC[pos + 1];
 
   // two identical CNOTs may not be applied in a row because they would cancel.
@@ -148,15 +148,15 @@ void MultiGateEncoder::assertTwoQubitGateOrderConstraints(
   // be conjugated with Hadamards) No Combination of Paulis on both Qubits
   // before a CNOT These gates can be just pushed through to the other side
   constexpr auto noneIndex = gateToIndex(qc::OpType::None);
-  const auto     noGate    = gSNow[noneIndex][ctrl] && gSNow[noneIndex][trgt];
-  const auto     noFurtherCnot = !gCNext[ctrl][trgt] && !gCNext[trgt][ctrl];
+  const auto noGate = gSNow[noneIndex][ctrl] && gSNow[noneIndex][trgt];
+  const auto noFurtherCnot = !gCNext[ctrl][trgt] && !gCNext[trgt][ctrl];
 
   constexpr auto hIndex = gateToIndex(qc::OpType::H);
   constexpr auto xIndex = gateToIndex(qc::OpType::X);
   constexpr auto zIndex = gateToIndex(qc::OpType::Z);
   constexpr auto yIndex = gateToIndex(qc::OpType::Y);
-  const auto     hh     = gSNow[hIndex][ctrl] && gSNow[hIndex][trgt];
-  const auto     gateBeforeCtrl =
+  const auto hh = gSNow[hIndex][ctrl] && gSNow[hIndex][trgt];
+  const auto gateBeforeCtrl =
       gSNow[zIndex][ctrl] || gSNow[xIndex][ctrl] || gSNow[yIndex][ctrl];
   const auto gateBeforeTarget =
       gSNow[zIndex][trgt] || gSNow[xIndex][trgt] || gSNow[yIndex][ctrl];
@@ -165,8 +165,8 @@ void MultiGateEncoder::assertTwoQubitGateOrderConstraints(
 }
 
 void MultiGateEncoder::splitXorR(const logicbase::LogicTerm& changes,
-                                 std::size_t                 pos) {
-  auto&             xorHelper = xorHelpers[pos];
+                                 std::size_t pos) {
+  auto& xorHelper = xorHelpers[pos];
   const std::string hName =
       "h_" + std::to_string(pos) + "_" + std::to_string(xorHelper.size());
   PLOG_DEBUG << "Creating helper variable for RChange XOR " << hName;

--- a/src/cliffordsynthesis/encoding/ObjectiveEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/ObjectiveEncoder.cpp
@@ -9,10 +9,10 @@
 #include "cliffordsynthesis/encoding/GateEncoder.hpp"
 #include "logicblocks/LogicTerm.hpp"
 #include "operations/OpType.hpp"
-#include "plog/Log.h"
 
 #include <cstddef>
 #include <functional>
+#include <plog/Log.h>
 #include <stdexcept>
 
 namespace cs::encoding {

--- a/src/cliffordsynthesis/encoding/ObjectiveEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/ObjectiveEncoder.cpp
@@ -45,8 +45,8 @@ void ObjectiveEncoder::optimizeDepth() const {
 
   constexpr auto noGateIndex = GateEncoder::gateToIndex(qc::OpType::None);
   for (std::size_t t = 0U; t < T; ++t) {
-    const auto& gS     = gvars->gS[t];
-    auto        noGate = LogicTerm(true);
+    const auto& gS = gvars->gS[t];
+    auto noGate = LogicTerm(true);
     for (std::size_t q = 0U; q < N; ++q) {
       noGate = noGate && gS[noGateIndex][q];
     }

--- a/src/cliffordsynthesis/encoding/SATEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/SATEncoder.cpp
@@ -5,13 +5,20 @@
 
 #include "cliffordsynthesis/encoding/SATEncoder.hpp"
 
+#include "Logic.hpp"
+#include "cliffordsynthesis/Results.hpp"
 #include "cliffordsynthesis/encoding/MultiGateEncoder.hpp"
+#include "cliffordsynthesis/encoding/ObjectiveEncoder.hpp"
 #include "cliffordsynthesis/encoding/SingleGateEncoder.hpp"
+#include "cliffordsynthesis/encoding/TableauEncoder.hpp"
 #include "logicblocks/util_logicblock.hpp"
-#include "plog/Log.h"
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <memory>
+#include <plog/Log.h>
 #include <stdexcept>
 #include <string>
 #include <variant>

--- a/src/cliffordsynthesis/encoding/SATEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/SATEncoder.cpp
@@ -22,7 +22,7 @@ using namespace logicbase;
 
 void SATEncoder::initializeSolver() {
   PLOG_DEBUG << "Initializing solver engine.";
-  bool              success = false;
+  bool success = false;
   logicutil::Params params;
   for (const auto& [key, value] : config.solverParameters) {
     if (std::holds_alternative<bool>(value)) {
@@ -108,9 +108,9 @@ void SATEncoder::createFormulation() {
 Result SATEncoder::solve() const {
   PLOG_INFO << "Solving the SAT instance.";
 
-  const auto start  = std::chrono::high_resolution_clock::now();
+  const auto start = std::chrono::high_resolution_clock::now();
   const auto result = lb->solve();
-  const auto end    = std::chrono::high_resolution_clock::now();
+  const auto end = std::chrono::high_resolution_clock::now();
   const auto runtime =
       std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
           .count();
@@ -135,7 +135,7 @@ Results SATEncoder::run() {
   createFormulation();
   const auto solverResult = solve();
 
-  const auto end     = std::chrono::high_resolution_clock::now();
+  const auto end = std::chrono::high_resolution_clock::now();
   const auto runtime = std::chrono::duration<double>(end - start);
 
   Results res{};

--- a/src/cliffordsynthesis/encoding/SingleGateEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/SingleGateEncoder.cpp
@@ -5,7 +5,13 @@
 
 #include "cliffordsynthesis/encoding/SingleGateEncoder.hpp"
 
-#include "plog/Log.h"
+#include "Logic.hpp"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <plog/Log.h>
+#include <plog/Severity.h>
+#include <utility>
 
 namespace cs::encoding {
 

--- a/src/cliffordsynthesis/encoding/SingleGateEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/SingleGateEncoder.cpp
@@ -44,7 +44,7 @@ void SingleGateEncoder::assertGateConstraints() {
 void SingleGateEncoder::assertNoGateNoChangeConstraint(const std::size_t pos) {
   for (std::size_t q = 0U; q < N; ++q) {
     const auto noChange = createNoChangeOnQubit(pos, q);
-    const auto noGate   = createNoGateOnQubit(pos, q);
+    const auto noGate = createNoGateOnQubit(pos, q);
     lb->assertFormula(LogicTerm::implies(noGate, noChange));
   }
 }
@@ -76,7 +76,7 @@ void SingleGateEncoder::assertTwoQubitGateConstraints(const std::size_t pos) {
 
 LogicTerm SingleGateEncoder::createTwoQubitGateConstraint(
     const std::size_t pos, const std::size_t ctrl, const std::size_t trgt) {
-  auto changes              = LogicTerm(true);
+  auto changes = LogicTerm(true);
   const auto [xCtrl, xTrgt] = tvars->twoQubitXChange(pos, ctrl, trgt);
   const auto [zCtrl, zTrgt] = tvars->twoQubitZChange(pos, ctrl, trgt);
 
@@ -94,15 +94,15 @@ LogicTerm SingleGateEncoder::createTwoQubitGateConstraint(
 LogicTerm SingleGateEncoder::createNoChangeOnQubit(const std::size_t pos,
                                                    const std::size_t q) {
   auto noChange = LogicTerm(true);
-  noChange      = noChange && (tvars->x[pos + 1][q] == tvars->x[pos][q]);
-  noChange      = noChange && (tvars->z[pos + 1][q] == tvars->z[pos][q]);
+  noChange = noChange && (tvars->x[pos + 1][q] == tvars->x[pos][q]);
+  noChange = noChange && (tvars->z[pos + 1][q] == tvars->z[pos][q]);
   return noChange;
 }
 
 LogicTerm SingleGateEncoder::createNoGateOnQubit(const std::size_t pos,
                                                  const std::size_t q) {
   const auto& singleQubitGates = vars.gS[pos];
-  auto        noGate           = LogicTerm(true);
+  auto noGate = LogicTerm(true);
   for (const auto& gate : SINGLE_QUBIT_GATES) {
     if (gate == qc::OpType::None) {
       continue;
@@ -129,7 +129,7 @@ void SingleGateEncoder::assertSingleQubitGateOrderConstraints(
   }
 
   // gate variables of the current and the next time step
-  const auto& gSNow  = vars.gS[pos];
+  const auto& gSNow = vars.gS[pos];
   const auto& gSNext = vars.gS[pos + 1];
 
   // collect variables of single-qubit gates that could be applied to `qubit`
@@ -160,7 +160,7 @@ void SingleGateEncoder::assertSingleQubitGateOrderConstraints(
   // once no gate is applied, no other gate can be applied, i.e., in the next
   // timestep any of the `None` gate variables must be selected.
   const auto noneIndex = gateToIndex(qc::OpType::None);
-  auto       noGate    = LogicTerm(false);
+  auto noGate = LogicTerm(false);
   for (std::size_t q = 0U; q < N; ++q) {
     noGate = noGate || gSNext[noneIndex][q];
   }

--- a/src/cliffordsynthesis/encoding/TableauEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/TableauEncoder.cpp
@@ -5,8 +5,18 @@
 
 #include "cliffordsynthesis/encoding/TableauEncoder.hpp"
 
+#include "Logic.hpp"
+#include "cliffordsynthesis/Results.hpp"
+#include "cliffordsynthesis/Tableau.hpp"
 #include "logicblocks/Model.hpp"
-#include "plog/Log.h"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <plog/Log.h>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace cs::encoding {
 

--- a/src/cliffordsynthesis/encoding/TableauEncoder.cpp
+++ b/src/cliffordsynthesis/encoding/TableauEncoder.cpp
@@ -40,7 +40,7 @@ void TableauEncoder::createTableauVariables() {
   }
 }
 
-void TableauEncoder::assertTableau(const Tableau&    tableau,
+void TableauEncoder::assertTableau(const Tableau& tableau,
                                    const std::size_t t) {
   const auto n = static_cast<std::uint16_t>(S);
 
@@ -58,9 +58,9 @@ void TableauEncoder::assertTableau(const Tableau&    tableau,
   lb->assertFormula(vars.r[t] == LogicTerm(targetR, n));
 }
 
-void TableauEncoder::extractTableauFromModel(Results&          results,
+void TableauEncoder::extractTableauFromModel(Results& results,
                                              const std::size_t t,
-                                             Model&            model) const {
+                                             Model& model) const {
   Tableau tableau(N, S > N);
   for (std::size_t i = 0; i < N; ++i) {
     const auto bvx = model.getBitvectorValue(vars.x[t][i], lb.get());
@@ -77,7 +77,7 @@ void TableauEncoder::extractTableauFromModel(Results&          results,
 LogicTerm
 TableauEncoder::Variables::singleQubitXChange(const std::size_t pos,
                                               const std::size_t qubit,
-                                              const qc::OpType  gate) const {
+                                              const qc::OpType gate) const {
   switch (gate) {
   case qc::OpType::None:
   case qc::OpType::X:
@@ -98,7 +98,7 @@ TableauEncoder::Variables::singleQubitXChange(const std::size_t pos,
 LogicTerm
 TableauEncoder::Variables::singleQubitZChange(const std::size_t pos,
                                               const std::size_t qubit,
-                                              const qc::OpType  gate) const {
+                                              const qc::OpType gate) const {
   switch (gate) {
   case qc::OpType::None:
   case qc::OpType::X:
@@ -120,7 +120,7 @@ TableauEncoder::Variables::singleQubitZChange(const std::size_t pos,
 LogicTerm
 TableauEncoder::Variables::singleQubitRChange(const std::size_t pos,
                                               const std::size_t qubit,
-                                              const qc::OpType  gate) const {
+                                              const qc::OpType gate) const {
   switch (gate) {
   case qc::OpType::None: {
     const auto bvs = r[pos].getBitVectorSize();

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -7,57 +7,57 @@
 
 nlohmann::json Configuration::json() const {
   nlohmann::json config{};
-  config["method"]            = ::toString(method);
+  config["method"] = ::toString(method);
   config["layering_strategy"] = ::toString(layering);
   if (!subgraph.empty()) {
     config["subgraph"] = subgraph;
   }
-  config["pre_mapping_optimizations"]          = preMappingOptimizations;
-  config["post_mapping_optimizations"]         = postMappingOptimizations;
+  config["pre_mapping_optimizations"] = preMappingOptimizations;
+  config["post_mapping_optimizations"] = postMappingOptimizations;
   config["add_measurements_to_mapped_circuit"] = addMeasurementsToMappedCircuit;
-  config["verbose"]                            = verbose;
-  config["debug"]                              = debug;
+  config["verbose"] = verbose;
+  config["debug"] = debug;
 
   if (method == Method::Heuristic) {
-    auto& heuristicJson           = config["settings"];
-    heuristicJson["heuristic"]    = ::toString(heuristic);
+    auto& heuristicJson = config["settings"];
+    heuristicJson["heuristic"] = ::toString(heuristic);
     auto& heuristicPropertiesJson = heuristicJson["heuristic_properties"];
     heuristicPropertiesJson["admissible"] = isAdmissible(heuristic);
     heuristicPropertiesJson["principally_admissible"] =
         isPrincipallyAdmissible(heuristic);
-    heuristicPropertiesJson["tight"]          = isTight(heuristic);
+    heuristicPropertiesJson["tight"] = isTight(heuristic);
     heuristicPropertiesJson["fidelity_aware"] = isFidelityAware(heuristic);
-    heuristicJson["initial_layout"]           = ::toString(initialLayout);
+    heuristicJson["initial_layout"] = ::toString(initialLayout);
     if (lookaheadHeuristic != LookaheadHeuristic::None) {
-      auto& lookaheadSettings        = heuristicJson["lookahead"];
+      auto& lookaheadSettings = heuristicJson["lookahead"];
       lookaheadSettings["heuristic"] = ::toString(lookaheadHeuristic);
       auto& lookaheadHeuristicPropertiesJson =
           lookaheadSettings["heuristic_properties"];
       lookaheadHeuristicPropertiesJson["fidelity_aware"] =
           isFidelityAware(lookaheadHeuristic);
-      lookaheadSettings["lookaheads"]   = nrLookaheads;
+      lookaheadSettings["lookaheads"] = nrLookaheads;
       lookaheadSettings["first_factor"] = firstLookaheadFactor;
-      lookaheadSettings["factor"]       = lookaheadFactor;
+      lookaheadSettings["factor"] = lookaheadFactor;
     }
     if (useTeleportation) {
-      auto& teleportation     = heuristicJson["teleportation"];
+      auto& teleportation = heuristicJson["teleportation"];
       teleportation["qubits"] = teleportationQubits;
-      teleportation["seed"]   = teleportationSeed;
-      teleportation["fake"]   = teleportationFake;
+      teleportation["seed"] = teleportationSeed;
+      teleportation["fake"] = teleportationFake;
     }
   }
 
   if (method == Method::Exact) {
-    auto& exact       = config["settings"];
-    exact["timeout"]  = timeout;
+    auto& exact = config["settings"];
+    exact["timeout"] = timeout;
     exact["encoding"] = ::toString(encoding);
     if (encoding == Encoding::Commander || encoding == Encoding::Bimander) {
       exact["commander_grouping"] = ::toString(commanderGrouping);
     }
     exact["include_WCNF"] = includeWCNF;
-    exact["use_subsets"]  = useSubsets;
+    exact["use_subsets"] = useSubsets;
     if (enableSwapLimits) {
-      auto& limits             = exact["limits"];
+      auto& limits = exact["limits"];
       limits["swap_reduction"] = ::toString(swapReduction);
       if (swapLimit > 0) {
         limits["swap_limit"] = swapLimit;

--- a/src/configuration/Configuration.cpp
+++ b/src/configuration/Configuration.cpp
@@ -5,8 +5,19 @@
 
 #include "configuration/Configuration.hpp"
 
-nlohmann::json Configuration::json() const {
-  nlohmann::json config{};
+#include "configuration/CommanderGrouping.hpp"
+#include "configuration/Encoding.hpp"
+#include "configuration/Heuristic.hpp"
+#include "configuration/InitialLayout.hpp"
+#include "configuration/Layering.hpp"
+#include "configuration/LookaheadHeuristic.hpp"
+#include "configuration/Method.hpp"
+#include "configuration/SwapReduction.hpp"
+
+#include <nlohmann/json.hpp>
+
+nlohmann::basic_json<> Configuration::json() const {
+  nlohmann::basic_json config{};
   config["method"] = ::toString(method);
   config["layering_strategy"] = ::toString(layering);
   if (!subgraph.empty()) {

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -13,7 +13,7 @@
 #include <cassert>
 
 void ExactMapper::map(const Configuration& settings) {
-  results.config     = settings;
+  results.config = settings;
   const auto& config = results.config;
 
   const std::chrono::high_resolution_clock::time_point start =
@@ -52,7 +52,7 @@ void ExactMapper::map(const Configuration& settings) {
     finalizeMappedCircuit();
 
     results.output.layers = results.input.layers;
-    results.time          = static_cast<std::chrono::duration<double>>(
+    results.time = static_cast<std::chrono::duration<double>>(
                        std::chrono::high_resolution_clock::now() - start)
                        .count();
     results.timeout = false;
@@ -99,8 +99,8 @@ void ExactMapper::map(const Configuration& settings) {
   mappingSwaps.reserve(reducedLayerIndices.size());
   std::size_t runs = 1;
   for (auto& choice : allPossibleQubitChoices) {
-    std::size_t       limit      = 0U;
-    std::size_t       maxLimit   = 0U;
+    std::size_t limit = 0U;
+    std::size_t maxLimit = 0U;
     const std::size_t upperLimit = config.swapLimit;
     if (config.useSubsets) {
       maxLimit = architecture->getCouplingLimit(choice) - 1U;
@@ -146,8 +146,8 @@ void ExactMapper::map(const Configuration& settings) {
 
       MappingResults choiceResults{};
       choiceResults.copyInput(results);
-      choiceResults.config.swapLimit        = limit;
-      choiceResults.output.swaps            = 0U;
+      choiceResults.config.swapLimit = limit;
+      choiceResults.output.swaps = 0U;
       choiceResults.output.directionReverse = 0U;
       choiceResults.output.gates = std::numeric_limits<std::size_t>::max();
 
@@ -191,7 +191,7 @@ void ExactMapper::map(const Configuration& settings) {
       // 7) Check if new optimum found
       if (!choiceResults.timeout &&
           choiceResults.output.gates < results.output.gates) {
-        results      = choiceResults;
+        results = choiceResults;
         mappingSwaps = swaps;
       }
       if (limit == 0) {
@@ -243,7 +243,7 @@ void ExactMapper::map(const Configuration& settings) {
       // no swaps but initial permutation
       for (const auto& [physical, logical] : *swapsIterator) {
         locations.at(logical) = static_cast<std::int16_t>(physical);
-        qubits.at(physical)   = static_cast<std::int16_t>(logical);
+        qubits.at(physical) = static_cast<std::int16_t>(logical);
         qcMapped.initialLayout[static_cast<qc::Qubit>(physical)] =
             static_cast<qc::Qubit>(logical);
       }
@@ -325,8 +325,8 @@ void ExactMapper::map(const Configuration& settings) {
       for (auto it = (*swapsIterator).rbegin(); it != (*swapsIterator).rend();
            ++it) {
         const auto& [q0, q1] = *it;
-        const auto logical0  = static_cast<qc::Qubit>(qubits.at(q0));
-        const auto logical1  = static_cast<qc::Qubit>(qubits.at(q1));
+        const auto logical0 = static_cast<qc::Qubit>(qubits.at(q0));
+        const auto logical1 = static_cast<qc::Qubit>(qubits.at(q1));
         qcMapped.swap(q0, q1);
         std::swap(qubits.at(q0), qubits.at(q1));
         locations.at(logical0) = static_cast<std::int16_t>(q1);
@@ -362,8 +362,8 @@ void ExactMapper::map(const Configuration& settings) {
 
   // 10) re-count gates
   results.output.singleQubitGates = 0U;
-  results.output.cnots            = 0U;
-  results.output.gates            = 0U;
+  results.output.cnots = 0U;
+  results.output.gates = 0U;
   countGates(qcMapped, results.output);
 
   // 11) final post-processing
@@ -371,7 +371,7 @@ void ExactMapper::map(const Configuration& settings) {
 
   auto end = std::chrono::high_resolution_clock::now();
   const std::chrono::duration<double> diff = end - start;
-  results.time                             = diff.count();
+  results.time = diff.count();
 }
 
 void ExactMapper::coreMappingRoutine(
@@ -382,7 +382,7 @@ void ExactMapper::coreMappingRoutine(
   const auto& config = results.config;
   using namespace logicbase;
   // LogicBlock
-  bool              success = false;
+  bool success = false;
   logicutil::Params params;
   params.addParam("timeout", static_cast<std::uint32_t>(timeout));
   params.addParam("pb.compile_equality", true);
@@ -395,12 +395,12 @@ void ExactMapper::coreMappingRoutine(
     throw QMAPException("Could not initialize Z3 logic block optimizer");
   }
 
-  std::vector<std::uint16_t>        pi(qubitChoice.begin(), qubitChoice.end());
-  std::uint64_t                     piCount{};
-  std::uint64_t                     internalPiCount{};
+  std::vector<std::uint16_t> pi(qubitChoice.begin(), qubitChoice.end());
+  std::uint64_t piCount{};
+  std::uint64_t internalPiCount{};
   std::unordered_set<std::uint64_t> skippedPi{};
   std::unordered_map<std::uint16_t, std::uint16_t> physicalQubitIndex{};
-  std::uint16_t                                    qIdx = 0;
+  std::uint16_t qIdx = 0;
   for (const auto& qubit : qubitChoice) {
     physicalQubitIndex[qubit] = qIdx;
     ++qIdx;
@@ -430,7 +430,7 @@ void ExactMapper::coreMappingRoutine(
   j	logical qubit j
   number of variables: (|L|) * m * n
   */
-  LogicMatrix3D     x{};
+  LogicMatrix3D x{};
   std::stringstream xName{};
   for (std::size_t k = 0; k < reducedLayerIndices.size(); ++k) {
     x.emplace_back();
@@ -451,7 +451,7 @@ k	before layer k
 pi	arbitrary permutation of the m qubits
 number of variables: (|L|-1) * m!
 */
-  LogicMatrix       y{};
+  LogicMatrix y{};
   std::stringstream yName{};
   for (std::size_t k = 1; k < reducedLayerIndices.size(); ++k) {
     y.emplace_back();
@@ -547,7 +547,7 @@ number of variables: (|L|-1) * m!
   } else if (config.encoding == Encoding::Bimander) {
     for (std::size_t k = 0; k < reducedLayerIndices.size(); ++k) {
       for (std::size_t i = 0; i < qubitChoice.size(); ++i) {
-        std::vector<LogicTerm>   vars;
+        std::vector<LogicTerm> vars;
         std::vector<std::size_t> varIDs;
         for (std::size_t j = 0; j < qc.getNqubits(); ++j) {
           vars.emplace_back(x[k][i][j]);
@@ -601,7 +601,7 @@ number of variables: (|L|-1) * m!
           auto indexFC = x[k][physicalQubitIndex[edge.first]]
                           [static_cast<std::size_t>(gate.control)];
           auto indexST = x[k][physicalQubitIndex[edge.second]][gate.target];
-          coupling     = coupling || (indexFC && indexST);
+          coupling = coupling || (indexFC && indexST);
         }
       } else {
         for (const auto& edge : rcm) {
@@ -624,10 +624,10 @@ number of variables: (|L|-1) * m!
   /// 	Permutation Constraints			//
   //////////////////////////////////////////
   for (std::size_t k = 1; k < reducedLayerIndices.size(); ++k) {
-    piCount         = 0;
+    piCount = 0;
     internalPiCount = 0;
-    auto& i         = x[k - 1];
-    auto& j         = x[k];
+    auto& i = x[k - 1];
+    auto& j = x[k];
     do {
       if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
         auto equal = LogicTerm(true);
@@ -649,8 +649,8 @@ number of variables: (|L|-1) * m!
   // Allow only 1 y_k_pi to be true
   if (config.encoding == Encoding::Naive) {
     for (std::size_t k = 1; k < reducedLayerIndices.size(); ++k) {
-      auto onlyOne    = LogicTerm(0);
-      piCount         = 0;
+      auto onlyOne = LogicTerm(0);
+      piCount = 0;
       internalPiCount = 0;
       do {
         if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
@@ -665,7 +665,7 @@ number of variables: (|L|-1) * m!
   } else {
     for (std::size_t k = 1; k < reducedLayerIndices.size(); ++k) {
       std::vector<LogicTerm> varIDs;
-      piCount         = 0;
+      piCount = 0;
       internalPiCount = 0;
       do {
         if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
@@ -696,9 +696,9 @@ number of variables: (|L|-1) * m!
   /// 	Objective Function				//
   //////////////////////////////////////////
   // cost for permutations
-  piCount         = 0;
+  piCount = 0;
   internalPiCount = 0;
-  auto cost       = LogicTerm(0);
+  auto cost = LogicTerm(0);
   do {
     if (skippedPi.count(piCount) == 0 || !config.swapLimitsEnabled()) {
       auto picost = architecture->minimumNumberOfSwaps(pi);
@@ -748,7 +748,7 @@ number of variables: (|L|-1) * m!
   lb->produceInstance();
   const auto res = lb->solve();
   if (Result::SAT == res) {
-    auto* const m         = lb->getModel();
+    auto* const m = lb->getModel();
     choiceResults.timeout = results.timeout = false;
 
     // quickly determine cost
@@ -793,7 +793,7 @@ number of variables: (|L|-1) * m!
         // used to infer the permutation of the qubits in each layer. This is
         // mainly because the additional qubits movement cannot be inferred
         // from the assignment matrices X.
-        piCount         = 0;
+        piCount = 0;
         internalPiCount = 0;
         // sort the permutation of the qubits to start fresh
         std::sort(pi.begin(), pi.end());

--- a/src/exact/ExactMapper.cpp
+++ b/src/exact/ExactMapper.cpp
@@ -5,12 +5,37 @@
 
 #include "exact/ExactMapper.hpp"
 
+#include "Architecture.hpp"
+#include "Definitions.hpp"
+#include "Logic.hpp"
+#include "LogicTerm.hpp"
+#include "configuration/CommanderGrouping.hpp"
+#include "configuration/Configuration.hpp"
+#include "configuration/Encoding.hpp"
+#include "configuration/SwapReduction.hpp"
 #include "logicblocks/Encodings.hpp"
 #include "logicblocks/LogicBlock.hpp"
 #include "logicblocks/Model.hpp"
 #include "logicblocks/util_logicblock.hpp"
+#include "operations/StandardOperation.hpp"
+#include "utils.hpp"
 
+#include <algorithm>
 #include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 void ExactMapper::map(const Configuration& settings) {
   results.config = settings;
@@ -64,8 +89,7 @@ void ExactMapper::map(const Configuration& settings) {
     const auto subgraphQubits = config.subgraph.size();
     if (subgraphQubits < qc.getNqubits()) {
       std::cerr << "The subgraph must contain at least as many qubits as the "
-                   "circuit has physical qubits."
-                << std::endl;
+                   "circuit has physical qubits.\n";
       return;
     }
 
@@ -133,7 +157,7 @@ void ExactMapper::map(const Configuration& settings) {
         }
         if (settings.verbose) {
           std::cout << "Timeout: " << timeout
-                    << "  Max-Timeout: " << settings.timeout << std::endl;
+                    << "  Max-Timeout: " << settings.timeout << '\n';
         }
       } else {
         timeout = settings.timeout;
@@ -228,7 +252,7 @@ void ExactMapper::map(const Configuration& settings) {
         std::cout << "(" << swap.first << "<->" << swap.second << ") ";
       }
       ++it;
-      std::cout << std::endl;
+      std::cout << '\n';
     }
   }
 

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -5,12 +5,37 @@
 
 #include "heuristic/HeuristicMapper.hpp"
 
+#include "Architecture.hpp"
+#include "DataLogger.hpp"
+#include "Definitions.hpp"
+#include "Mapper.hpp"
+#include "configuration/Configuration.hpp"
+#include "configuration/EarlyTermination.hpp"
+#include "configuration/Heuristic.hpp"
+#include "configuration/InitialLayout.hpp"
+#include "configuration/Layering.hpp"
+#include "configuration/LookaheadHeuristic.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
 #include "utils.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <random>
+#include <set>
+#include <utility>
+#include <vector>
 
 void HeuristicMapper::map(const Configuration& configuration) {
   if (configuration.dataLoggingEnabled()) {

--- a/src/heuristic/HeuristicMapper.cpp
+++ b/src/heuristic/HeuristicMapper.cpp
@@ -18,11 +18,11 @@ void HeuristicMapper::map(const Configuration& configuration) {
                                               *architecture, qc);
   }
 
-  tightHeur         = isTight(configuration.heuristic);
+  tightHeur = isTight(configuration.heuristic);
   fidelityAwareHeur = isFidelityAware(configuration.heuristic);
 
-  results            = MappingResults{};
-  results.config     = configuration;
+  results = MappingResults{};
+  results.config = configuration;
   const auto& config = results.config;
   checkParameters();
   const auto start = std::chrono::steady_clock::now();
@@ -66,10 +66,10 @@ void HeuristicMapper::map(const Configuration& configuration) {
   countGates(qcMapped, results.output);
   finalizeMappedCircuit();
 
-  const auto                          end  = std::chrono::steady_clock::now();
+  const auto end = std::chrono::steady_clock::now();
   const std::chrono::duration<double> diff = end - start;
-  results.time                             = diff.count();
-  results.timeout                          = false;
+  results.time = diff.count();
+  results.timeout = false;
 
   if (config.dataLoggingEnabled()) {
     dataLogger->logOutputCircuit(qcMapped);
@@ -91,7 +91,7 @@ void HeuristicMapper::staticInitialMapping() {
         qubits.at(q1) = static_cast<std::int16_t>(gate.target);
         locations.at(static_cast<std::uint16_t>(gate.control)) =
             static_cast<std::int16_t>(q0);
-        locations.at(gate.target)     = static_cast<std::int16_t>(q1);
+        locations.at(gate.target) = static_cast<std::int16_t>(q1);
         qcMapped.initialLayout.at(q0) = static_cast<qc::Qubit>(gate.control);
         qcMapped.initialLayout.at(q1) = static_cast<qc::Qubit>(gate.target);
         qcMapped.outputPermutation.at(q0) =
@@ -107,9 +107,9 @@ void HeuristicMapper::staticInitialMapping() {
     if (qc.initialLayout.count(i) > 0 && locations.at(i) == DEFAULT_POSITION) {
       for (qc::Qubit j = 0U; j < architecture->getNqubits(); ++j) {
         if (qubits.at(j) == DEFAULT_POSITION) {
-          locations.at(i)                  = static_cast<std::int16_t>(j);
-          qubits.at(j)                     = static_cast<std::int16_t>(i);
-          qcMapped.initialLayout.at(j)     = i;
+          locations.at(i) = static_cast<std::int16_t>(j);
+          qubits.at(j) = static_cast<std::int16_t>(i);
+          qcMapped.initialLayout.at(j) = i;
           qcMapped.outputPermutation.at(j) = i;
           break;
         }
@@ -153,7 +153,7 @@ void HeuristicMapper::createInitialMapping() {
     std::mt19937_64 mt;
     if (config.teleportationSeed == 0) {
       std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
-                         randomData{};
+          randomData{};
       std::random_device rd;
       std::generate(std::begin(randomData), std::end(randomData),
                     [&rd]() { return rd(); });
@@ -174,11 +174,11 @@ void HeuristicMapper::createInitialMapping() {
         std::advance(it, dis(mt));
         e = *it;
       } while (qubits.at(e.first) != -1 || qubits.at(e.second) != -1);
-      const auto teleportationQubit    = qc.getNqubits() + i;
+      const auto teleportationQubit = qc.getNqubits() + i;
       locations.at(teleportationQubit) = static_cast<std::int16_t>(e.first);
       locations.at(teleportationQubit + 1) =
           static_cast<std::int16_t>(e.second);
-      qubits.at(e.first)  = static_cast<std::int16_t>(teleportationQubit);
+      qubits.at(e.first) = static_cast<std::int16_t>(teleportationQubit);
       qubits.at(e.second) = static_cast<std::int16_t>(teleportationQubit + 1);
     }
 
@@ -192,7 +192,7 @@ void HeuristicMapper::createInitialMapping() {
     for (qc::Qubit i = 0; i < architecture->getNqubits(); ++i) {
       if (qc.initialLayout.count(i) > 0) {
         locations.at(i) = static_cast<std::int16_t>(i);
-        qubits.at(i)    = static_cast<std::int16_t>(i);
+        qubits.at(i) = static_cast<std::int16_t>(i);
       }
     }
     break;
@@ -221,7 +221,7 @@ void HeuristicMapper::mapUnmappedGates(std::size_t layer) {
         for (std::uint16_t physQbit = 0; physQbit < architecture->getNqubits();
              ++physQbit) {
           if (qubits.at(physQbit) == -1) {
-            locations.at(q)     = static_cast<std::int16_t>(physQbit);
+            locations.at(q) = static_cast<std::int16_t>(physQbit);
             qubits.at(physQbit) = static_cast<std::int16_t>(q);
             break;
           }
@@ -257,7 +257,7 @@ void HeuristicMapper::mapUnmappedGates(std::size_t layer) {
                 qubits.at(j) == DEFAULT_POSITION) {
               const double dist = architecture->distance(i, j);
               if (dist < bestScore) {
-                bestScore  = dist;
+                bestScore = dist;
                 chosenEdge = std::make_pair(i, j);
               }
             }
@@ -270,7 +270,7 @@ void HeuristicMapper::mapUnmappedGates(std::size_t layer) {
       // should be chosen
       locations.at(q1) = static_cast<std::int16_t>(chosenEdge.first);
       locations.at(q2) = static_cast<std::int16_t>(chosenEdge.second);
-      qubits.at(chosenEdge.first)  = static_cast<std::int16_t>(q1);
+      qubits.at(chosenEdge.first) = static_cast<std::int16_t>(q1);
       qubits.at(chosenEdge.second) = static_cast<std::int16_t>(q2);
       qc::QuantumComputation::findAndSWAP(q1, chosenEdge.first,
                                           qcMapped.initialLayout);
@@ -290,7 +290,7 @@ void HeuristicMapper::mapUnmappedGates(std::size_t layer) {
 
 void HeuristicMapper::mapToMinDistance(const std::uint16_t source,
                                        const std::uint16_t target) {
-  auto                         min = std::numeric_limits<double>::max();
+  auto min = std::numeric_limits<double>::max();
   std::optional<std::uint16_t> pos = std::nullopt;
   for (std::uint16_t i = 0; i < architecture->getNqubits(); ++i) {
     if (qubits.at(i) == DEFAULT_POSITION) {
@@ -304,7 +304,7 @@ void HeuristicMapper::mapToMinDistance(const std::uint16_t source,
     }
   }
   assert(pos.has_value());
-  qubits.at(*pos)      = static_cast<std::int16_t>(target);
+  qubits.at(*pos) = static_cast<std::int16_t>(target);
   locations.at(target) = static_cast<std::int16_t>(*pos);
   qc::QuantumComputation::findAndSWAP(target, *pos, qcMapped.initialLayout);
   qc::QuantumComputation::findAndSWAP(target, *pos, qcMapped.outputPermutation);
@@ -312,23 +312,23 @@ void HeuristicMapper::mapToMinDistance(const std::uint16_t source,
 
 void HeuristicMapper::pseudoRouteCircuit(bool reverse) {
   // save original global data for restoring it later
-  const auto originalResults                   = results;
-  const auto originalLayers                    = layers;
+  const auto originalResults = results;
+  const auto originalLayers = layers;
   const auto originalSingleQubitMultiplicities = singleQubitMultiplicities;
-  const auto originalTwoQubitMultiplicities    = twoQubitMultiplicities;
-  const auto originalActiveQubits              = activeQubits;
-  const auto originalActiveQubits1QGates       = activeQubits1QGates;
-  const auto originalActiveQubits2QGates       = activeQubits2QGates;
+  const auto originalTwoQubitMultiplicities = twoQubitMultiplicities;
+  const auto originalActiveQubits = activeQubits;
+  const auto originalActiveQubits1QGates = activeQubits1QGates;
+  const auto originalActiveQubits2QGates = activeQubits2QGates;
 
-  auto& config           = results.config;
+  auto& config = results.config;
   config.dataLoggingPath = ""; // disable data logging for pseudo routing
-  config.debug           = false;
+  config.debug = false;
 
   for (std::size_t i = 0; i < layers.size(); ++i) {
     const auto layerIndex = (reverse ? layers.size() - i - 1 : i);
-    const Node result     = aStarMap(layerIndex, reverse);
+    const Node result = aStarMap(layerIndex, reverse);
 
-    qubits    = result.qubits;
+    qubits = result.qubits;
     locations = result.locations;
 
     if (config.verbose) {
@@ -338,25 +338,25 @@ void HeuristicMapper::pseudoRouteCircuit(bool reverse) {
   }
 
   // restore original global data
-  results                   = originalResults;
-  layers                    = originalLayers;
+  results = originalResults;
+  layers = originalLayers;
   singleQubitMultiplicities = originalSingleQubitMultiplicities;
-  twoQubitMultiplicities    = originalTwoQubitMultiplicities;
-  activeQubits              = originalActiveQubits;
-  activeQubits1QGates       = originalActiveQubits1QGates;
-  activeQubits2QGates       = originalActiveQubits2QGates;
+  twoQubitMultiplicities = originalTwoQubitMultiplicities;
+  activeQubits = originalActiveQubits;
+  activeQubits1QGates = originalActiveQubits1QGates;
+  activeQubits2QGates = originalActiveQubits2QGates;
 }
 
 void HeuristicMapper::routeCircuit() {
   const auto& config = results.config;
 
-  std::size_t              gateidx = 0;
+  std::size_t gateidx = 0;
   std::vector<std::size_t> gatesToAdjust{};
   results.output.gates = 0U;
   for (std::size_t layerIndex = 0; layerIndex < layers.size(); ++layerIndex) {
     const Node result = aStarMap(layerIndex, false);
 
-    qubits    = result.qubits;
+    qubits = result.qubits;
     locations = result.locations;
 
     if (config.verbose) {
@@ -484,8 +484,8 @@ void HeuristicMapper::routeCircuit() {
             "circuit contains only StandardOperations");
       }
       if (op->getType() == qc::SWAP) {
-        const auto q0                     = qubits.at(op->getTargets().at(0));
-        const auto q1                     = qubits.at(op->getTargets().at(1));
+        const auto q0 = qubits.at(op->getTargets().at(0));
+        const auto q1 = qubits.at(op->getTargets().at(1));
         qubits.at(op->getTargets().at(0)) = q1;
         qubits.at(op->getTargets().at(1)) = q0;
 
@@ -500,7 +500,7 @@ void HeuristicMapper::routeCircuit() {
       }
       if (!gatesToAdjust.empty() && gatesToAdjust.back() == gateidx) {
         gatesToAdjust.pop_back();
-        const auto target         = op->getTargets().at(0);
+        const auto target = op->getTargets().at(0);
         const auto targetLocation = locations.at(target);
 
         if (targetLocation == -1) {
@@ -511,11 +511,11 @@ void HeuristicMapper::routeCircuit() {
             ++loc;
           }
           locations.at(target) = static_cast<std::int16_t>(loc);
-          qubits.at(loc)       = static_cast<std::int16_t>(target);
+          qubits.at(loc) = static_cast<std::int16_t>(target);
           op->setTargets({static_cast<qc::Qubit>(loc)});
-          qcMapped.initialLayout.at(loc)                          = target;
+          qcMapped.initialLayout.at(loc) = target;
           qcMapped.outputPermutation[static_cast<qc::Qubit>(loc)] = target;
-          qcMapped.garbage.at(loc)                                = false;
+          qcMapped.garbage.at(loc) = false;
         } else {
           op->setTargets({static_cast<qc::Qubit>(targetLocation)});
         }
@@ -536,7 +536,7 @@ void HeuristicMapper::routeCircuit() {
 
 HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
   const auto& config = results.config;
-  nextNodeId         = 0;
+  nextNodeId = 0;
 
   const SingleQubitMultiplicity& singleQubitMultiplicity =
       singleQubitMultiplicities.at(layer);
@@ -549,7 +549,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
   mapUnmappedGates(layer);
 
   node.locations = locations;
-  node.qubits    = qubits;
+  node.qubits = qubits;
   recalculateFixedCost(layer, node);
   updateHeuristicCost(layer, node);
   updateLookaheadPenalty(layer, node);
@@ -562,13 +562,13 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
   }
   nodes.push(node);
 
-  const auto  start         = std::chrono::steady_clock::now();
+  const auto start = std::chrono::steady_clock::now();
   std::size_t expandedNodes = 0;
-  std::size_t expandedNodesAfterFirstSolution   = 0;
+  std::size_t expandedNodesAfterFirstSolution = 0;
   std::size_t expandedNodesAfterOptimalSolution = 0;
-  std::size_t solutionNodes                     = 0;
+  std::size_t solutionNodes = 0;
   std::size_t solutionNodesAfterOptimalSolution = 0;
-  bool        earlyTermination                  = false;
+  bool earlyTermination = false;
 
   const bool splittable =
       config.automaticLayerSplits ? isLayerSplittable(layer) : false;
@@ -603,7 +603,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
       ++solutionNodes;
       if (!validMapping ||
           current.getTotalFixedCost() < bestDoneNode.getTotalFixedCost()) {
-        bestDoneNode                      = current;
+        bestDoneNode = current;
         expandedNodesAfterOptimalSolution = 0;
         solutionNodesAfterOptimalSolution = 0;
       } else {
@@ -658,7 +658,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
   if (config.debug) {
     const auto end = std::chrono::steady_clock::now();
     results.layerHeuristicBenchmark.emplace_back();
-    auto layerResultsIt           = results.layerHeuristicBenchmark.rbegin();
+    auto layerResultsIt = results.layerHeuristicBenchmark.rbegin();
     layerResultsIt->expandedNodes = expandedNodes;
     results.heuristicBenchmark.expandedNodes += expandedNodes;
 
@@ -712,7 +712,7 @@ HeuristicMapper::Node HeuristicMapper::aStarMap(size_t layer, bool reverse) {
 }
 
 void HeuristicMapper::expandNode(Node& node, std::size_t layer) {
-  const auto&                    consideredQubits = getConsideredQubits(layer);
+  const auto& consideredQubits = getConsideredQubits(layer);
   std::vector<std::vector<bool>> usedSwaps;
   usedSwaps.reserve(architecture->getNqubits());
   for (int p = 0; p < architecture->getNqubits(); ++p) {
@@ -731,7 +731,7 @@ void HeuristicMapper::expandNode(Node& node, std::size_t layer) {
     for (auto const& g : architecture->getCouplingMap()) {
       if (g.first == node.locations.at(qc.getNqubits() + i) &&
           g.second != node.locations.at(qc.getNqubits() + i + 1)) {
-        e.first  = g.second;
+        e.first = g.second;
         e.second = static_cast<std::uint16_t>(
             node.locations.at(qc.getNqubits() + i + 1));
         architecture->getCurrentTeleportations().insert(e);
@@ -739,7 +739,7 @@ void HeuristicMapper::expandNode(Node& node, std::size_t layer) {
       }
       if (g.second == node.locations.at(qc.getNqubits() + i) &&
           g.first != node.locations.at(qc.getNqubits() + i + 1)) {
-        e.first  = g.first;
+        e.first = g.first;
         e.second = static_cast<std::uint16_t>(
             node.locations.at(qc.getNqubits() + i + 1));
         architecture->getCurrentTeleportations().insert(e);
@@ -812,8 +812,8 @@ void HeuristicMapper::recalculateFixedCost(std::size_t layer, Node& node) {
   node.validMappedTwoQubitGates.clear();
   for (const auto& [edge, mult] : twoQubitMultiplicities.at(layer)) {
     const auto [q1, q2] = edge;
-    const auto physQ1   = static_cast<std::uint16_t>(node.locations.at(q1));
-    const auto physQ2   = static_cast<std::uint16_t>(node.locations.at(q2));
+    const auto physQ1 = static_cast<std::uint16_t>(node.locations.at(q1));
+    const auto physQ2 = static_cast<std::uint16_t>(node.locations.at(q2));
 
     if (architecture->isEdgeConnected({physQ1, physQ2}, false)) {
       // validly mapped
@@ -830,7 +830,7 @@ void HeuristicMapper::recalculateFixedCost(std::size_t layer, Node& node) {
 }
 
 void HeuristicMapper::recalculateFixedCostReversals(std::size_t layer,
-                                                    Node&       node) {
+                                                    Node& node) {
   node.costFixedReversals = 0.;
   if (architecture->bidirectional() || fidelityAwareHeur ||
       node.validMappedTwoQubitGates.size() !=
@@ -843,7 +843,7 @@ void HeuristicMapper::recalculateFixedCostReversals(std::size_t layer,
 
   // only consider reversal costs as fixed in goal nodes
   for (const auto& [edge, mult] : twoQubitMultiplicities.at(layer)) {
-    const auto [q1, q2]                   = edge;
+    const auto [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = mult;
     const auto physQ1 = static_cast<std::uint16_t>(node.locations.at(q1));
     const auto physQ2 = static_cast<std::uint16_t>(node.locations.at(q2));
@@ -882,9 +882,9 @@ void HeuristicMapper::recalculateFixedCostNonFidelity(Node& node) {
 }
 
 void HeuristicMapper::recalculateFixedCostFidelity(std::size_t layer,
-                                                   Node&       node) {
+                                                   Node& node) {
   const auto& singleQubitGateMultiplicity = singleQubitMultiplicities.at(layer);
-  const auto& twoQubitGateMultiplicity    = twoQubitMultiplicities.at(layer);
+  const auto& twoQubitGateMultiplicity = twoQubitMultiplicities.at(layer);
 
   node.costFixed = 0;
   // adding costs of single qubit gates
@@ -913,7 +913,7 @@ void HeuristicMapper::recalculateFixedCostFidelity(std::size_t layer,
       // 2-qubit-gates not yet validly mapped are handled in the heuristic
       continue;
     }
-    const auto [q1, q2]                   = edge;
+    const auto [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = mult;
     const auto physQ1 = static_cast<std::uint16_t>(node.locations.at(q1));
     const auto physQ2 = static_cast<std::uint16_t>(node.locations.at(q2));
@@ -934,7 +934,7 @@ void HeuristicMapper::applySWAP(const Edge& swap, std::size_t layer,
 
   updateSharedSwaps(swap, layer, node);
 
-  node.qubits.at(swap.first)  = q2;
+  node.qubits.at(swap.first) = q2;
   node.qubits.at(swap.second) = q1;
 
   if (q1 != -1) {
@@ -1045,7 +1045,7 @@ void HeuristicMapper::applyTeleportation(const Edge& swap, std::size_t layer,
 
   updateSharedSwaps(swap, layer, node);
 
-  node.qubits.at(swap.first)  = q2;
+  node.qubits.at(swap.first) = q2;
   node.qubits.at(swap.second) = q1;
 
   if (q1 != -1) {
@@ -1115,7 +1115,7 @@ void HeuristicMapper::applyTeleportation(const Edge& swap, std::size_t layer,
 
 void HeuristicMapper::updateSharedSwaps(const Edge& swap, std::size_t layer,
                                         Node& node) {
-  const auto& consideredQubits         = getConsideredQubits(layer);
+  const auto& consideredQubits = getConsideredQubits(layer);
   const auto& twoQubitGateMultiplicity = twoQubitMultiplicities.at(layer);
 
   const auto q1 = node.qubits.at(swap.first);
@@ -1156,9 +1156,9 @@ void HeuristicMapper::updateSharedSwaps(const Edge& swap, std::size_t layer,
         static_cast<std::uint16_t>(node.locations.at(logEdge2.second));
 
     double logEdge1DistanceBefore = 0.;
-    double logEdge1DistanceNew    = 0.;
+    double logEdge1DistanceNew = 0.;
     double logEdge2DistanceBefore = 0.;
-    double logEdge2DistanceNew    = 0.;
+    double logEdge2DistanceNew = 0.;
     if (fidelityAwareHeur) {
       logEdge1DistanceBefore =
           std::min(architecture->fidelityDistance(swap.first, physQ3),
@@ -1221,14 +1221,14 @@ void HeuristicMapper::updateHeuristicCost(std::size_t layer, Node& node) {
 }
 
 double HeuristicMapper::heuristicGateCountMaxDistance(std::size_t layer,
-                                                      Node&       node) {
+                                                      Node& node) {
   if (node.validMapping) {
     return 0.;
   }
   double costHeur = 0.;
 
   for (const auto& [edge, multiplicity] : twoQubitMultiplicities.at(layer)) {
-    const auto& [q1, q2]                  = edge;
+    const auto& [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = multiplicity;
     const auto physQ1 = static_cast<std::uint16_t>(node.locations.at(q1));
     const auto physQ2 = static_cast<std::uint16_t>(node.locations.at(q2));
@@ -1261,14 +1261,14 @@ double HeuristicMapper::heuristicGateCountMaxDistance(std::size_t layer,
 }
 
 double HeuristicMapper::heuristicGateCountSumDistance(std::size_t layer,
-                                                      Node&       node) {
+                                                      Node& node) {
   if (node.validMapping) {
     return 0.;
   }
   double costHeur = 0.;
 
   for (const auto& [edge, multiplicity] : twoQubitMultiplicities.at(layer)) {
-    const auto& [q1, q2]                  = edge;
+    const auto& [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = multiplicity;
     const auto physQ1 = static_cast<std::uint16_t>(node.locations.at(q1));
     const auto physQ2 = static_cast<std::uint16_t>(node.locations.at(q2));
@@ -1310,13 +1310,13 @@ double HeuristicMapper::heuristicGateCountSumDistanceMinusSharedSwaps(
     return 0.;
   }
   const auto& twoQubitGateMultiplicity = twoQubitMultiplicities.at(layer);
-  double      costHeur                 = 0.;
-  double      costReversals            = 0.;
+  double costHeur = 0.;
+  double costReversals = 0.;
   std::vector<std::size_t> nSwaps{};
   nSwaps.reserve(twoQubitGateMultiplicity.size());
 
   for (const auto& [edge, multiplicity] : twoQubitGateMultiplicity) {
-    const auto& [q1, q2]                  = edge;
+    const auto& [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = multiplicity;
     const auto physQ1 = static_cast<std::uint16_t>(node.locations.at(q1));
     const auto physQ2 = static_cast<std::uint16_t>(node.locations.at(q2));
@@ -1401,10 +1401,10 @@ HeuristicMapper::heuristicGateCountMaxDistanceOrSumDistanceMinusSharedSwaps(
 }
 
 double HeuristicMapper::heuristicFidelityBestLocation(std::size_t layer,
-                                                      Node&       node) {
-  const auto& consideredQubits            = getConsideredQubits(layer);
+                                                      Node& node) {
+  const auto& consideredQubits = getConsideredQubits(layer);
   const auto& singleQubitGateMultiplicity = singleQubitMultiplicities.at(layer);
-  const auto& twoQubitGateMultiplicity    = twoQubitMultiplicities.at(layer);
+  const auto& twoQubitGateMultiplicity = twoQubitMultiplicities.at(layer);
 
   double costHeur = 0.;
 
@@ -1416,7 +1416,7 @@ double HeuristicMapper::heuristicFidelityBestLocation(std::size_t layer,
     if (singleQubitGateMultiplicity.at(logQbit) == 0) {
       continue;
     }
-    double       qbitSavings  = 0;
+    double qbitSavings = 0;
     const double currFidelity = architecture->getSingleQubitFidelityCost(
         static_cast<std::uint16_t>(node.locations.at(logQbit)));
     for (std::uint16_t physQbit = 0U; physQbit < architecture->getNqubits();
@@ -1439,7 +1439,7 @@ double HeuristicMapper::heuristicFidelityBestLocation(std::size_t layer,
   // iterating over all virtual qubit pairs, that share a gate on the
   // current layer
   for (const auto& [edge, mult] : twoQubitGateMultiplicity) {
-    const auto [q1, q2]                   = edge;
+    const auto [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = mult;
 
     const bool edgeDone = (node.validMappedTwoQubitGates.find(edge) !=
@@ -1494,12 +1494,12 @@ double HeuristicMapper::heuristicFidelityBestLocation(std::size_t layer,
   return costHeur - savingsPotential;
 }
 
-void HeuristicMapper::updateLookaheadPenalty(const std::size_t      layer,
+void HeuristicMapper::updateLookaheadPenalty(const std::size_t layer,
                                              HeuristicMapper::Node& node) {
-  const auto& config    = results.config;
+  const auto& config = results.config;
   node.lookaheadPenalty = 0.;
-  auto   nextLayer      = getNextLayer(layer);
-  double factor         = config.firstLookaheadFactor;
+  auto nextLayer = getNextLayer(layer);
+  double factor = config.firstLookaheadFactor;
 
   for (std::size_t i = 0; i < config.nrLookaheads; ++i) {
     if (nextLayer == std::numeric_limits<std::size_t>::max()) {
@@ -1526,12 +1526,12 @@ void HeuristicMapper::updateLookaheadPenalty(const std::size_t      layer,
 }
 
 double
-HeuristicMapper::lookaheadGateCountMaxDistance(const std::size_t      layer,
+HeuristicMapper::lookaheadGateCountMaxDistance(const std::size_t layer,
                                                HeuristicMapper::Node& node) {
   double penalty = 0.;
 
   for (const auto& [edge, multiplicity] : twoQubitMultiplicities.at(layer)) {
-    const auto& [q1, q2]                  = edge;
+    const auto& [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = multiplicity;
 
     const auto loc1 = node.locations.at(q1);
@@ -1590,12 +1590,12 @@ HeuristicMapper::lookaheadGateCountMaxDistance(const std::size_t      layer,
 }
 
 double
-HeuristicMapper::lookaheadGateCountSumDistance(const std::size_t      layer,
+HeuristicMapper::lookaheadGateCountSumDistance(const std::size_t layer,
                                                HeuristicMapper::Node& node) {
   double penalty = 0.;
 
   for (const auto& [edge, multiplicity] : twoQubitMultiplicities.at(layer)) {
-    const auto& [q1, q2]                  = edge;
+    const auto& [q1, q2] = edge;
     const auto [forwardMult, reverseMult] = multiplicity;
 
     const auto loc1 = node.locations.at(q1);

--- a/src/hybridmap/HardwareQubits.cpp
+++ b/src/hybridmap/HardwareQubits.cpp
@@ -37,14 +37,14 @@ void HardwareQubits::initNearbyQubits() {
 }
 
 void HardwareQubits::computeSwapDistance(HwQubit q1, HwQubit q2) {
-  std::queue<HwQubit>  q;
-  std::vector<bool>    visited(swapDistances.size(), false);
+  std::queue<HwQubit> q;
+  std::vector<bool> visited(swapDistances.size(), false);
   std::vector<HwQubit> parent(swapDistances.size(), q2);
 
   q.push(q1);
   visited[q1] = true;
-  parent[q1]  = q1;
-  bool found  = false;
+  parent[q1] = q1;
+  bool found = false;
   while (!q.empty() && !found) {
     auto current = q.front();
     q.pop();
@@ -52,7 +52,7 @@ void HardwareQubits::computeSwapDistance(HwQubit q1, HwQubit q2) {
       if (!visited[nearbyQubit]) {
         q.push(nearbyQubit);
         visited[nearbyQubit] = true;
-        parent[nearbyQubit]  = current;
+        parent[nearbyQubit] = current;
         if (nearbyQubit == q2) {
           found = true;
           break;
@@ -66,7 +66,7 @@ void HardwareQubits::computeSwapDistance(HwQubit q1, HwQubit q2) {
   }
   // recreate path
   std::vector<HwQubit> path;
-  auto                 current = q2;
+  auto current = q2;
   while (current != q1) {
     path.emplace_back(current);
     current = parent[current];
@@ -129,7 +129,7 @@ std::vector<Swap> HardwareQubits::getNearbySwaps(HwQubit q) const {
 
 void HardwareQubits::computeNearbyQubits(HwQubit q) {
   std::set<HwQubit> newNearbyQubits;
-  auto              coordQ = hwToCoordIdx.at(q);
+  auto coordQ = hwToCoordIdx.at(q);
   for (const auto& coord : hwToCoordIdx) {
     if (coord.first == q) {
       continue;
@@ -203,7 +203,7 @@ HardwareQubits::findClosestFreeCoord(CoordIndex coord, Direction direction,
   // return the closest free coord in general
   // and the closest free coord in the given direction
   std::vector<CoordIndex> closestFreeCoords;
-  std::queue<CoordIndex>  queue;
+  std::queue<CoordIndex> queue;
   queue.push(coord);
   std::set<CoordIndex> visited;
   visited.emplace(coord);

--- a/src/hybridmap/HybridAnimation.cpp
+++ b/src/hybridmap/HybridAnimation.cpp
@@ -21,15 +21,15 @@
 
 namespace na {
 AnimationAtoms::AnimationAtoms(const std::map<HwQubit, HwQubit>& initHwPos,
-                               const NeutralAtomArchitecture&    arch) {
+                               const NeutralAtomArchitecture& arch) {
   auto nCols = arch.getNcolumns();
 
   for (const auto& [id, coord] : initHwPos) {
     coordIdxToId[coord] = id;
-    auto column         = coord % nCols;
-    auto row            = coord / nCols;
-    idToCoord[id]       = {column * arch.getInterQubitDistance(),
-                           row * arch.getInterQubitDistance()};
+    auto column = coord % nCols;
+    auto row = coord / nCols;
+    idToCoord[id] = {column * arch.getInterQubitDistance(),
+                     row * arch.getInterQubitDistance()};
   }
 }
 
@@ -94,10 +94,10 @@ AnimationAtoms::createCsvOp(const std::unique_ptr<qc::Operation>& op,
       // if yes -> update coordIdxToId with new coordIdx
       // if not -> throw exception
       for (const auto& idAndCoord : idToCoord) {
-        auto id    = idAndCoord.first;
+        auto id = idAndCoord.first;
         auto coord = idAndCoord.second;
-        auto col   = coordIdx % arch.getNcolumns();
-        auto row   = coordIdx / arch.getNcolumns();
+        auto col = coordIdx % arch.getNcolumns();
+        auto row = coordIdx / arch.getNcolumns();
         if (std::abs(coord.first - col * arch.getInterQubitDistance()) <
                 0.0001 &&
             std::abs(coord.second - row * arch.getInterQubitDistance()) <
@@ -121,7 +121,7 @@ AnimationAtoms::createCsvOp(const std::unique_ptr<qc::Operation>& op,
                           std::to_string(coordIdx) +
                           " but there is no qubit at this coordIdx");
     }
-    auto id    = coordIdxToId.at(coordIdx);
+    auto id = coordIdxToId.at(coordIdx);
     auto coord = idToCoord.at(id);
     if (op->getType() == qc::OpType::AodActivate) {
       addAxis(id);

--- a/src/hybridmap/HybridNeutralAtomMapper.cpp
+++ b/src/hybridmap/HybridNeutralAtomMapper.cpp
@@ -36,8 +36,8 @@ namespace na {
 qc::QuantumComputation NeutralAtomMapper::map(qc::QuantumComputation& qc,
                                               InitialMapping initialMapping) {
   mappedQc = qc::QuantumComputation(arch.getNpositions());
-  nMoves   = 0;
-  nSwaps   = 0;
+  nMoves = 0;
+  nSwaps = 0;
   qc::CircuitOptimizer::replaceMCXWithMCZ(qc);
   qc::CircuitOptimizer::singleQubitGateFusion(qc);
   qc::CircuitOptimizer::flattenOperations(qc);
@@ -83,7 +83,7 @@ qc::QuantumComputation NeutralAtomMapper::map(qc::QuantumComputation& qc,
           std::cout << "iteration " << i << '\n';
         }
         auto bestSwap = findBestSwap(lastSwap);
-        lastSwap      = bestSwap;
+        lastSwap = bestSwap;
         updateMappingSwap(bestSwap);
         gatesToExecute = getExecutableGates(frontLayer.getGates());
       }
@@ -200,15 +200,15 @@ void NeutralAtomMapper::mapGate(const qc::Operation* op) {
     std::cout << "\n";
   }
   // convert circuit qubits to CoordIndex and append to mappedQc
-  auto  opCopyUnique = op->clone();
-  auto* opCopy       = opCopyUnique.get();
+  auto opCopyUnique = op->clone();
+  auto* opCopy = opCopyUnique.get();
   this->mapping.mapToHwQubits(opCopy);
   this->hardwareQubits.mapToCoordIdx(opCopy);
   this->mappedQc.emplace_back(opCopy->clone());
 }
 
 bool NeutralAtomMapper::isExecutable(const qc::Operation* opPointer) {
-  auto usedQubits  = opPointer->getUsedQubits();
+  auto usedQubits = opPointer->getUsedQubits();
   auto nUsedQubits = usedQubits.size();
   if (nUsedQubits == 1) {
     return true;
@@ -277,7 +277,7 @@ void NeutralAtomMapper::updateMappingSwap(Swap swap) {
   }
   this->mapping.applySwap(swap);
   // convert circuit qubits to CoordIndex and append to mappedQc
-  auto idxFirst  = this->hardwareQubits.getCoordIndex(swap.first);
+  auto idxFirst = this->hardwareQubits.getCoordIndex(swap.first);
   auto idxSecond = this->hardwareQubits.getCoordIndex(swap.second);
   this->mappedQc.swap(idxFirst, idxSecond);
   if (this->parameters.verbose) {
@@ -319,7 +319,7 @@ void NeutralAtomMapper::updateMappingMove(AtomMove move) {
 
 Swap NeutralAtomMapper::findBestSwap(const Swap& lastSwap) {
   // compute necessary movements
-  auto swapsFront     = initSwaps(this->frontLayerGate);
+  auto swapsFront = initSwaps(this->frontLayerGate);
   auto swapsLookahead = initSwaps(this->lookaheadLayerGate);
   setTwoQubitSwapWeight(swapsFront.second);
 
@@ -386,7 +386,7 @@ std::set<Swap> NeutralAtomMapper::getAllPossibleSwaps(
 qc::fp NeutralAtomMapper::swapCost(
     const Swap& swap, const std::pair<Swaps, WeightedSwaps>& swapsFront,
     const std::pair<Swaps, WeightedSwaps>& swapsLookahead) {
-  auto [swapCloseByFront, swapExactFront]         = swapsFront;
+  auto [swapCloseByFront, swapExactFront] = swapsFront;
   auto [swapCloseByLookahead, swapExactLookahead] = swapsLookahead;
   // compute the change in total distance
   auto distanceChangeFront =
@@ -419,11 +419,11 @@ qc::fp NeutralAtomMapper::swapCost(
 
 std::pair<Swaps, WeightedSwaps>
 NeutralAtomMapper::initSwaps(const GateList& layer) {
-  Swaps         swapCloseBy = {};
-  WeightedSwaps swapExact   = {};
+  Swaps swapCloseBy = {};
+  WeightedSwaps swapExact = {};
   // computes for each gate the necessary moves to execute it
   for (const auto& gate : layer) {
-    auto usedQubits   = gate->getUsedQubits();
+    auto usedQubits = gate->getUsedQubits();
     auto usedHwQubits = this->mapping.getHwQubits(usedQubits);
     if (usedQubits.size() == 2) {
       // swap close by for two qubit gates
@@ -453,12 +453,12 @@ NeutralAtomMapper::initSwaps(const GateList& layer) {
   return {swapCloseBy, swapExact};
 }
 
-qc::fp NeutralAtomMapper::swapCostPerLayer(const Swap&          swap,
-                                           const Swaps&         swapCloseBy,
+qc::fp NeutralAtomMapper::swapCostPerLayer(const Swap& swap,
+                                           const Swaps& swapCloseBy,
                                            const WeightedSwaps& swapExact) {
   SwapDistance distBefore = 0;
-  SwapDistance distAfter  = 0;
-  qc::fp       distChange = 0;
+  SwapDistance distAfter = 0;
+  qc::fp distChange = 0;
   // bring close only until swap distance =0, bring exact to the exact position
   // bring qubits together to execute gate
   for (const auto& [q1, q2] : swapCloseBy) {
@@ -485,7 +485,7 @@ qc::fp NeutralAtomMapper::swapCostPerLayer(const Swap&          swap,
 
   // move qubits to the exact position for multi-qubit gates
   for (const auto& [exactSwap, weight] : swapExact) {
-    auto origin      = exactSwap.first;
+    auto origin = exactSwap.first;
     auto destination = exactSwap.second;
     distBefore =
         this->hardwareQubits.getSwapDistance(origin, destination, false);
@@ -526,7 +526,7 @@ HwQubits NeutralAtomMapper::getBestMultiQubitPosition(const qc::Operation* op) {
                       std::vector<std::pair<qc::fp, HwQubit>>, std::greater<>>
       qubitQueue;
   // add the gate qubits to the priority queue
-  auto gateQubits   = op->getUsedQubits();
+  auto gateQubits = op->getUsedQubits();
   auto gateHwQubits = this->mapping.getHwQubits(gateQubits);
   // add the gate qubits to the priority queue
   for (const auto& gateQubit : gateHwQubits) {
@@ -602,7 +602,7 @@ HwQubits NeutralAtomMapper::getBestMultiQubitPositionRec(
     return bestPos;
   }
   // update remainingNearbyQubits
-  auto newQubit        = *selectedQubits.rbegin();
+  auto newQubit = *selectedQubits.rbegin();
   auto nearbyNextQubit = this->hardwareQubits.getNearbyQubits(newQubit);
   // compute remaining qubits as the intersection with current
   Qubits newRemainingQubits;
@@ -655,7 +655,7 @@ HwQubits NeutralAtomMapper::getBestMultiQubitPositionRec(
         this->hardwareQubits.getSwapDistance(gateQubit, nextQubit, true);
     if (distance < closesDistance) {
       closesGateQubits = gateQubit;
-      closesDistance   = distance;
+      closesDistance = distance;
     }
   }
   remainingGateQubits.erase(remainingGateQubits.find(closesGateQubits));
@@ -666,16 +666,16 @@ HwQubits NeutralAtomMapper::getBestMultiQubitPositionRec(
 
 WeightedSwaps
 NeutralAtomMapper::getExactSwapsToPosition(const qc::Operation* op,
-                                           HwQubits             position) {
+                                           HwQubits position) {
   if (position.empty()) {
     return {};
   }
-  auto          gateQubits   = op->getUsedQubits();
-  auto          gateHwQubits = this->mapping.getHwQubits(gateQubits);
+  auto gateQubits = op->getUsedQubits();
+  auto gateHwQubits = this->mapping.getHwQubits(gateQubits);
   WeightedSwaps swapsExact;
   while (!position.empty() && !gateHwQubits.empty()) {
     std::vector<std::tuple<HwQubit, std::set<HwQubit>, SwapDistance>>
-                      minimalDistances;
+        minimalDistances;
     std::set<HwQubit> minimalDistancePosQubit;
     for (const auto& gateQubit : gateHwQubits) {
       SwapDistance minimalDistance = std::numeric_limits<SwapDistance>::max();
@@ -808,8 +808,8 @@ qc::fp NeutralAtomMapper::moveCostComb(const MoveComb& moveComb) {
 }
 
 qc::fp NeutralAtomMapper::moveCost(const AtomMove& move) {
-  qc::fp cost      = 0;
-  auto   frontCost = moveCostPerLayer(move, this->frontLayerShuttling) /
+  qc::fp cost = 0;
+  auto frontCost = moveCostPerLayer(move, this->frontLayerShuttling) /
                    static_cast<qc::fp>(this->frontLayerShuttling.size());
   cost += frontCost;
   if (!lookaheadLayerShuttling.empty()) {
@@ -830,10 +830,10 @@ qc::fp NeutralAtomMapper::moveCost(const AtomMove& move) {
 }
 
 qc::fp NeutralAtomMapper::moveCostPerLayer(const AtomMove& move,
-                                           GateList&       layer) {
+                                           GateList& layer) {
   // compute cost assuming the move was applied
-  qc::fp distChange    = 0;
-  auto   toMoveHwQubit = this->hardwareQubits.getHwQubit(move.first);
+  qc::fp distChange = 0;
+  auto toMoveHwQubit = this->hardwareQubits.getHwQubit(move.first);
   if (this->mapping.isMapped(toMoveHwQubit)) {
     auto toMoveCircuitQubit = this->mapping.getCircQubit(toMoveHwQubit);
     for (const auto& gate : layer) {
@@ -846,7 +846,7 @@ qc::fp NeutralAtomMapper::moveCostPerLayer(const AtomMove& move,
             continue;
           }
           auto hwQubit = this->mapping.getHwQubit(qubit);
-          auto dist    = this->arch.getEuclideanDistance(
+          auto dist = this->arch.getEuclideanDistance(
               this->hardwareQubits.getCoordIndex(hwQubit),
               this->hardwareQubits.getCoordIndex(toMoveHwQubit));
           distanceBefore += dist;
@@ -857,7 +857,7 @@ qc::fp NeutralAtomMapper::moveCostPerLayer(const AtomMove& move,
             continue;
           }
           auto hwQubit = this->mapping.getHwQubit(qubit);
-          auto dist    = this->arch.getEuclideanDistance(
+          auto dist = this->arch.getEuclideanDistance(
               this->hardwareQubits.getCoordIndex(hwQubit), move.second);
           distanceAfter += dist;
         }
@@ -870,7 +870,7 @@ qc::fp NeutralAtomMapper::moveCostPerLayer(const AtomMove& move,
 
 qc::fp NeutralAtomMapper::parallelMoveCost(const AtomMove& move) {
   qc::fp parallelCost = 0;
-  auto   moveVector   = this->arch.getVector(move.first, move.second);
+  auto moveVector = this->arch.getVector(move.first, move.second);
   std::vector<CoordIndex> lastEndingCoords;
   if (this->lastMoves.empty()) {
     parallelCost += arch.getVectorShuttlingTime(moveVector);
@@ -893,12 +893,12 @@ qc::fp NeutralAtomMapper::parallelMoveCost(const AtomMove& move) {
   // check if in same row/column like last moves
   // then can may be loaded in parallel
   auto moveCoordInit = this->arch.getCoordinate(move.first);
-  auto moveCoordEnd  = this->arch.getCoordinate(move.second);
+  auto moveCoordEnd = this->arch.getCoordinate(move.second);
   parallelCost += arch.getShuttlingTime(qc::OpType::AodActivate) +
                   arch.getShuttlingTime(qc::OpType::AodDeactivate);
   for (const auto& lastMove : this->lastMoves) {
     auto lastMoveCoordInit = this->arch.getCoordinate(lastMove.first);
-    auto lastMoveCoordEnd  = this->arch.getCoordinate(lastMove.second);
+    auto lastMoveCoordEnd = this->arch.getCoordinate(lastMove.second);
     if (moveCoordInit.x == lastMoveCoordInit.x ||
         moveCoordInit.y == lastMoveCoordInit.y) {
       parallelCost -= arch.getShuttlingTime(qc::OpType::AodActivate);
@@ -919,9 +919,9 @@ qc::fp NeutralAtomMapper::parallelMoveCost(const AtomMove& move) {
 }
 
 MultiQubitMovePos
-NeutralAtomMapper::getMovePositionRec(MultiQubitMovePos   currentPos,
+NeutralAtomMapper::getMovePositionRec(MultiQubitMovePos currentPos,
                                       const CoordIndices& gateCoords,
-                                      const size_t&       maxNMoves) {
+                                      const size_t& maxNMoves) {
   if (currentPos.coords.size() == gateCoords.size()) {
     return currentPos;
   }
@@ -964,11 +964,11 @@ NeutralAtomMapper::getMovePositionRec(MultiQubitMovePos   currentPos,
   }
 
   // compute minimal possible moves
-  size_t       minPossibleMoves = currentPos.nMoves;
-  size_t const nMissingQubits   = gateCoords.size() - currentPos.coords.size();
-  auto         itGate           = occupiedGateCoords.begin();
-  auto         itFree           = freeNearbyCoords.begin();
-  auto         itOcc            = occupiedNearbyCoords.begin();
+  size_t minPossibleMoves = currentPos.nMoves;
+  size_t const nMissingQubits = gateCoords.size() - currentPos.coords.size();
+  auto itGate = occupiedGateCoords.begin();
+  auto itFree = freeNearbyCoords.begin();
+  auto itOcc = occupiedNearbyCoords.begin();
   for (size_t i = 0; i < nMissingQubits; ++i) {
     if (itGate != occupiedGateCoords.end()) {
       ++itGate;
@@ -1020,13 +1020,13 @@ NeutralAtomMapper::getMovePositionRec(MultiQubitMovePos   currentPos,
 MoveCombs NeutralAtomMapper::getAllMoveCombinations() {
   MoveCombs allMoves;
   for (const auto& op : this->frontLayerShuttling) {
-    auto usedQubits    = op->getUsedQubits();
-    auto usedHwQubits  = this->mapping.getHwQubits(usedQubits);
+    auto usedQubits = op->getUsedQubits();
+    auto usedHwQubits = this->mapping.getHwQubits(usedQubits);
     auto usedCoordsSet = this->hardwareQubits.getCoordIndices(usedHwQubits);
     auto usedCoords =
         std::vector<CoordIndex>(usedCoordsSet.begin(), usedCoordsSet.end());
     auto bestPos = getBestMovePos(usedCoords);
-    auto moves   = getMoveCombinationsToPosition(usedHwQubits, bestPos);
+    auto moves = getMoveCombinationsToPosition(usedHwQubits, bestPos);
     allMoves.addMoveCombs(moves);
   }
   allMoves.removeLongerMoveCombs();
@@ -1034,9 +1034,9 @@ MoveCombs NeutralAtomMapper::getAllMoveCombinations() {
 }
 
 CoordIndices NeutralAtomMapper::getBestMovePos(const CoordIndices& gateCoords) {
-  size_t const maxMoves   = gateCoords.size() * 2;
-  size_t const minMoves   = gateCoords.size();
-  size_t       nMovesGate = maxMoves;
+  size_t const maxMoves = gateCoords.size() * 2;
+  size_t const minMoves = gateCoords.size();
+  size_t nMovesGate = maxMoves;
   // do a breadth first search for the best position
   // start with the used coords
   std::queue<CoordIndex> q;
@@ -1086,20 +1086,20 @@ CoordIndices NeutralAtomMapper::getBestMovePos(const CoordIndices& gateCoords) {
 }
 
 MoveCombs
-NeutralAtomMapper::getMoveCombinationsToPosition(HwQubits&     gateQubits,
+NeutralAtomMapper::getMoveCombinationsToPosition(HwQubits& gateQubits,
                                                  CoordIndices& position) {
   if (position.empty()) {
     throw qc::QFRException("No position given");
   }
   // compute for each qubit the best position around it based on the cost of
   // the single move choose best one
-  MoveCombs const      moveCombinations;
+  MoveCombs const moveCombinations;
   std::set<CoordIndex> gateQubitCoords;
   for (const auto& gateQubit : gateQubits) {
     gateQubitCoords.emplace(this->hardwareQubits.getCoordIndex(gateQubit));
   }
 
-  auto     remainingCoords = position;
+  auto remainingCoords = position;
   MoveComb moveComb;
   // compute cost for each candidate and each gateQubit
   auto remainingGateCoords = gateQubitCoords;
@@ -1134,8 +1134,8 @@ NeutralAtomMapper::getMoveCombinationsToPosition(HwQubits&     gateQubits,
       }
     }
     // find minimal cost
-    auto bestCost  = std::min_element(costs.begin(), costs.end(),
-                                      [](const auto& cost1, const auto& cost2) {
+    auto bestCost = std::min_element(costs.begin(), costs.end(),
+                                     [](const auto& cost1, const auto& cost2) {
                                        return cost1.second < cost2.second;
                                      });
     auto bestCoord = bestCost->first;
@@ -1156,17 +1156,17 @@ NeutralAtomMapper::getMoveCombinationsToPosition(HwQubits&     gateQubits,
 }
 
 MoveCombs
-NeutralAtomMapper::getMoveAwayCombinations(CoordIndex          startCoord,
-                                           CoordIndex          targetCoord,
+NeutralAtomMapper::getMoveAwayCombinations(CoordIndex startCoord,
+                                           CoordIndex targetCoord,
                                            const CoordIndices& excludedCoords) {
-  MoveCombs  moveCombinations;
-  auto const originalVector    = this->arch.getVector(startCoord, targetCoord);
+  MoveCombs moveCombinations;
+  auto const originalVector = this->arch.getVector(startCoord, targetCoord);
   auto const originalDirection = originalVector.direction;
   // Find move away target in the same direction as the original move
   auto moveAwayTargets = this->hardwareQubits.findClosestFreeCoord(
       targetCoord, originalDirection, excludedCoords);
   for (const auto& moveAwayTarget : moveAwayTargets) {
-    const AtomMove move     = {startCoord, targetCoord};
+    const AtomMove move = {startCoord, targetCoord};
     const AtomMove moveAway = {targetCoord, moveAwayTarget};
     moveCombinations.addMoveComb(MoveComb({moveAway, move}));
   }
@@ -1178,9 +1178,9 @@ NeutralAtomMapper::getMoveAwayCombinations(CoordIndex          startCoord,
 
 std::pair<uint32_t, qc::fp>
 NeutralAtomMapper::estimateNumSwapGates(const qc::Operation* opPointer) {
-  auto   usedQubits   = opPointer->getUsedQubits();
-  auto   usedHwQubits = this->mapping.getHwQubits(usedQubits);
-  qc::fp minNumSwaps  = 0;
+  auto usedQubits = opPointer->getUsedQubits();
+  auto usedHwQubits = this->mapping.getHwQubits(usedQubits);
+  qc::fp minNumSwaps = 0;
   if (usedHwQubits.size() == 2) {
     SwapDistance minDistance = std::numeric_limits<SwapDistance>::max();
     for (const auto& hwQubit : usedHwQubits) {
@@ -1216,9 +1216,9 @@ NeutralAtomMapper::estimateNumSwapGates(const qc::Operation* opPointer) {
 
 std::pair<uint32_t, qc::fp>
 NeutralAtomMapper::estimateNumMove(const qc::Operation* opPointer) {
-  auto usedQubits   = opPointer->getUsedQubits();
+  auto usedQubits = opPointer->getUsedQubits();
   auto usedHwQubits = this->mapping.getHwQubits(usedQubits);
-  auto usedCoords   = this->hardwareQubits.getCoordIndices(usedHwQubits);
+  auto usedCoords = this->hardwareQubits.getCoordIndices(usedHwQubits);
   // estimate the number of moves as:
   // compute distance between qubits
   // 1. for each free coord in the vicinity = 1 move with corresponding
@@ -1227,17 +1227,17 @@ NeutralAtomMapper::estimateNumMove(const qc::Operation* opPointer) {
   // distance
 
   uint32_t minMoves = std::numeric_limits<uint32_t>::max();
-  qc::fp   minTime  = std::numeric_limits<qc::fp>::max();
+  qc::fp minTime = std::numeric_limits<qc::fp>::max();
   for (const auto& coord : usedCoords) {
-    qc::fp   totalTime  = 0;
+    qc::fp totalTime = 0;
     uint32_t totalMoves = 0;
-    auto     nearbyFreeCoords =
+    auto nearbyFreeCoords =
         this->hardwareQubits.getNearbyFreeCoordinatesByCoord(coord);
     auto nearbyOccupiedCoords =
         this->hardwareQubits.getNearbyOccupiedCoordinatesByCoord(coord);
     auto otherQubitsIt = usedCoords.begin();
-    auto nearbyFreeIt  = nearbyFreeCoords.begin();
-    auto nearbyOccIt   = nearbyOccupiedCoords.begin();
+    auto nearbyFreeIt = nearbyFreeCoords.begin();
+    auto nearbyOccIt = nearbyOccupiedCoords.begin();
     while (otherQubitsIt != usedCoords.end()) {
       auto otherCoord = *otherQubitsIt;
       if (otherCoord == coord) {
@@ -1271,7 +1271,7 @@ NeutralAtomMapper::estimateNumMove(const qc::Operation* opPointer) {
     }
 
     if (totalTime < minTime) {
-      minTime  = totalTime;
+      minTime = totalTime;
       minMoves = totalMoves;
     }
   }

--- a/src/hybridmap/MoveToAodConverter.cpp
+++ b/src/hybridmap/MoveToAodConverter.cpp
@@ -36,8 +36,8 @@ MoveToAodConverter::schedule(qc::QuantumComputation& qc) {
 
   // create new quantum circuit and insert AOD operations at the correct
   // indices
-  auto     groupIt = moveGroups.begin();
-  uint32_t idx     = 0;
+  auto groupIt = moveGroups.begin();
+  uint32_t idx = 0;
   for (const auto& op : qc) {
     if (groupIt != moveGroups.end() && idx == groupIt->getFirstIdx()) {
       // add move group
@@ -60,9 +60,9 @@ MoveToAodConverter::schedule(qc::QuantumComputation& qc) {
 }
 
 void MoveToAodConverter::initMoveGroups(qc::QuantumComputation& qc) {
-  MoveGroup       currentMoveGroup;
+  MoveGroup currentMoveGroup;
   MoveGroup const lastMoveGroup;
-  uint32_t        idx = 0;
+  uint32_t idx = 0;
   for (auto& op : qc) {
     if (op->getType() == qc::OpType::Move) {
       AtomMove const move{op->getTargets()[0], op->getTargets()[1]};
@@ -103,7 +103,7 @@ bool MoveToAodConverter::MoveGroup::canAdd(
       moves.begin(), moves.end(),
       [&moveVector, &archArg](const std::pair<AtomMove, uint32_t> opPair) {
         auto moveGroup = opPair.first;
-        auto opVector  = archArg.getVector(moveGroup.first, moveGroup.second);
+        auto opVector = archArg.getVector(moveGroup.first, moveGroup.second);
         return parallelCheck(moveVector, opVector);
       });
 }
@@ -125,7 +125,7 @@ bool MoveToAodConverter::MoveGroup::parallelCheck(const MoveVector& v1,
 }
 
 void MoveToAodConverter::MoveGroup::add(const AtomMove& move,
-                                        const uint32_t  idx) {
+                                        const uint32_t idx) {
   moves.emplace_back(move, idx);
   qubitsUsedByGates.emplace_back(move.second);
 }
@@ -133,14 +133,14 @@ void MoveToAodConverter::MoveGroup::add(const AtomMove& move,
 void MoveToAodConverter::AodActivationHelper::addActivation(
     std::pair<ActivationMergeType, ActivationMergeType> merge,
     const Point& origin, const AtomMove& move, MoveVector v) {
-  const auto x         = static_cast<std::uint32_t>(origin.x);
-  const auto y         = static_cast<std::uint32_t>(origin.y);
-  const auto signX     = v.direction.getSignX();
-  const auto signY     = v.direction.getSignY();
-  const auto deltaX    = v.xEnd - v.xStart;
-  const auto deltaY    = v.yEnd - v.yStart;
-  auto       aodMovesX = getAodMovesFromInit(Dimension::X, x);
-  auto       aodMovesY = getAodMovesFromInit(Dimension::Y, y);
+  const auto x = static_cast<std::uint32_t>(origin.x);
+  const auto y = static_cast<std::uint32_t>(origin.y);
+  const auto signX = v.direction.getSignX();
+  const auto signY = v.direction.getSignY();
+  const auto deltaX = v.xEnd - v.xStart;
+  const auto deltaY = v.yEnd - v.yStart;
+  auto aodMovesX = getAodMovesFromInit(Dimension::X, x);
+  auto aodMovesY = getAodMovesFromInit(Dimension::Y, y);
 
   switch (merge.first) {
   case ActivationMergeType::Trivial:
@@ -232,7 +232,7 @@ MoveToAodConverter::canAddActivation(
       static_cast<std::uint32_t>(dim == Dimension::X ? final.x : final.y);
 
   // Get Moves that start/end at the same position as the current move
-  auto aodMovesActivation   = activationHelper.getAodMovesFromInit(dim, start);
+  auto aodMovesActivation = activationHelper.getAodMovesFromInit(dim, start);
   auto aodMovesDeactivation = deactivationHelper.getAodMovesFromInit(dim, end);
 
   // both empty
@@ -304,16 +304,16 @@ void MoveToAodConverter::processMoveGroups() {
        ++groupIt) {
     AodActivationHelper aodActivationHelper{arch, qc::OpType::AodActivate};
     AodActivationHelper aodDeactivationHelper{arch, qc::OpType::AodDeactivate};
-    MoveGroup           possibleNewMoveGroup;
+    MoveGroup possibleNewMoveGroup;
     std::vector<AtomMove> movesToRemove;
     for (auto& movePair : groupIt->moves) {
-      auto& move     = movePair.first;
-      auto  idx      = movePair.second;
-      auto  origin   = arch.getCoordinate(move.first);
-      auto  target   = arch.getCoordinate(move.second);
-      auto  v        = arch.getVector(move.first, move.second);
-      auto  vReverse = arch.getVector(move.second, move.first);
-      auto  canAddX =
+      auto& move = movePair.first;
+      auto idx = movePair.second;
+      auto origin = arch.getCoordinate(move.first);
+      auto target = arch.getCoordinate(move.second);
+      auto v = arch.getVector(move.first, move.second);
+      auto vReverse = arch.getVector(move.second, move.first);
+      auto canAddX =
           canAddActivation(aodActivationHelper, aodDeactivationHelper, origin,
                            v, target, vReverse, Dimension::X);
       auto canAddY =
@@ -351,8 +351,8 @@ void MoveToAodConverter::processMoveGroups() {
       possibleNewMoveGroup = MoveGroup();
       groupIt--;
     }
-    groupIt->processedOpsInit   = aodActivationHelper.getAodOperations();
-    groupIt->processedOpsFinal  = aodDeactivationHelper.getAodOperations();
+    groupIt->processedOpsInit = aodActivationHelper.getAodOperations();
+    groupIt->processedOpsFinal = aodDeactivationHelper.getAodOperations();
     groupIt->processedOpShuttle = MoveGroup::connectAodOperations(
         groupIt->processedOpsInit, groupIt->processedOpsFinal);
   }
@@ -365,7 +365,7 @@ AodOperation MoveToAodConverter::MoveGroup::connectAodOperations(
   // and connect with an aod move operations
   // all can be done in parallel in a single move
   std::vector<SingleOperation> aodOperations;
-  std::set<CoordIndex>         targetQubits;
+  std::set<CoordIndex> targetQubits;
 
   for (const auto& opInit : opsInit) {
     if (opInit.getType() == qc::OpType::AodMove) {
@@ -383,13 +383,13 @@ AodOperation MoveToAodConverter::MoveGroup::connectAodOperations(
             // found corresponding final operation
             // connect with aod move
             const auto startXs = opInit.getEnds(Dimension::X);
-            const auto endXs   = opFinal.getStarts(Dimension::X);
+            const auto endXs = opFinal.getStarts(Dimension::X);
             const auto startYs = opInit.getEnds(Dimension::Y);
-            const auto endYs   = opFinal.getStarts(Dimension::Y);
+            const auto endYs = opFinal.getStarts(Dimension::Y);
             if (!startXs.empty() && !endXs.empty()) {
               for (size_t i = 0; i < startXs.size(); i++) {
                 const auto startX = startXs[i];
-                const auto endX   = endXs[i];
+                const auto endX = endXs[i];
                 if (std::abs(startX - endX) > 0.0001) {
                   aodOperations.emplace_back(Dimension::X, startX, endX);
                 }
@@ -398,7 +398,7 @@ AodOperation MoveToAodConverter::MoveGroup::connectAodOperations(
             if (!startYs.empty() && !endYs.empty()) {
               for (size_t i = 0; i < startYs.size(); i++) {
                 const auto startY = startYs[i];
-                const auto endY   = endYs[i];
+                const auto endY = endYs[i];
                 if (std::abs(startY - endY) > 0.0001) {
                   aodOperations.emplace_back(Dimension::Y, startY, endY);
                 }
@@ -455,7 +455,7 @@ bool MoveToAodConverter::AodActivationHelper::checkIntermediateSpaceAtInit(
   } else {
     neighborX -= 1;
   }
-  auto aodMoves         = getAodMovesFromInit(dim, init);
+  auto aodMoves = getAodMovesFromInit(dim, init);
   auto aodMovesNeighbor = getAodMovesFromInit(dim, neighborX);
   if (aodMoves.empty() && aodMovesNeighbor.empty()) {
     return true;
@@ -526,7 +526,7 @@ MoveToAodConverter::AodActivationHelper::getAodOperation(
   std::vector<SingleOperation> initOperations;
   std::vector<SingleOperation> offsetOperations;
 
-  auto d      = this->arch.getInterQubitDistance();
+  auto d = this->arch.getInterQubitDistance();
   auto interD = this->arch.getInterQubitDistance() /
                 this->arch.getNAodIntermediateLevels();
 

--- a/src/hybridmap/NeutralAtomArchitecture.cpp
+++ b/src/hybridmap/NeutralAtomArchitecture.cpp
@@ -29,7 +29,7 @@ namespace na {
 
 void NeutralAtomArchitecture::loadJson(const std::string& filename) {
   nlohmann::json jsonData;
-  std::ifstream  architectureFile(filename);
+  std::ifstream architectureFile(filename);
 
   if (!architectureFile.is_open()) {
     throw std::runtime_error("Could not open file " + filename);
@@ -40,7 +40,7 @@ void NeutralAtomArchitecture::loadJson(const std::string& filename) {
 
     // Load properties
     nlohmann::json jsonDataProperties = jsonData["properties"];
-    this->properties                  = Properties(
+    this->properties = Properties(
         jsonDataProperties["nRows"], jsonDataProperties["nColumns"],
         jsonDataProperties["nAods"], jsonDataProperties["nAodCoordinates"],
         jsonDataProperties["interQubitDistance"],
@@ -50,8 +50,8 @@ void NeutralAtomArchitecture::loadJson(const std::string& filename) {
 
     // Load parameters
     const nlohmann::json jsonDataParameters = jsonData["parameters"];
-    this->parameters                        = Parameters();
-    this->parameters.nQubits                = jsonDataParameters["nQubits"];
+    this->parameters = Parameters();
+    this->parameters.nQubits = jsonDataParameters["nQubits"];
 
     // check if qubits can fit in the architecture
     if (this->parameters.nQubits > this->properties.getNpositions()) {
@@ -76,7 +76,7 @@ void NeutralAtomArchitecture::loadJson(const std::string& filename) {
       shuttlingTimes.emplace(qc::OP_NAME_TO_TYPE.at(key), value);
     }
     // compute values for SWAP gate
-    qc::fp swapGateTime     = 0;
+    qc::fp swapGateTime = 0;
     qc::fp swapGateFidelity = 1;
     for (size_t i = 0; i < 3; ++i) {
       swapGateTime += gateTimes.at("cz");
@@ -130,7 +130,7 @@ void NeutralAtomArchitecture::computeSwapDistances(qc::fp interactionRadius) {
   struct DiagonalDistance {
     std::uint32_t x;
     std::uint32_t y;
-    qc::fp        distance;
+    qc::fp distance;
   };
   std::vector<DiagonalDistance> diagonalDistances;
 
@@ -223,10 +223,10 @@ qc::fp NeutralAtomArchitecture::getOpTime(const qc::Operation* op) const {
     return getShuttlingTime(op->getType());
   }
   if (op->getType() == qc::OpType::AodMove) {
-    const auto        v = this->parameters.shuttlingTimes.at(op->getType());
+    const auto v = this->parameters.shuttlingTimes.at(op->getType());
     const auto* const opAodMove = dynamic_cast<const AodOperation*>(op);
-    const auto        distanceX = opAodMove->getMaxDistance(Dimension::X);
-    const auto        distanceY = opAodMove->getMaxDistance(Dimension::Y);
+    const auto distanceX = opAodMove->getMaxDistance(Dimension::X);
+    const auto distanceY = opAodMove->getMaxDistance(Dimension::Y);
     return (distanceX + distanceY) / v;
   }
   std::string opName;

--- a/src/hybridmap/NeutralAtomLayer.cpp
+++ b/src/hybridmap/NeutralAtomLayer.cpp
@@ -73,7 +73,7 @@ void NeutralAtomLayer::updateCandidatesByQubits(
         bool commutes = true;
         while (commutes && tempIter < this->dag[qubit].end()) {
           auto* nextOp = (*tempIter)->get();
-          commutes     = commutesWithAtQubit(gates, nextOp, qubit) &&
+          commutes = commutesWithAtQubit(gates, nextOp, qubit) &&
                      commutesWithAtQubit(candidates[qubit], nextOp, qubit);
           if (commutes) {
             if (nextOp->getUsedQubits().size() == 1) {
@@ -150,9 +150,9 @@ void NeutralAtomLayer::removeGatesAndUpdate(const GateList& gatesToRemove) {
 
 // Commutation
 
-bool NeutralAtomLayer::commutesWithAtQubit(const GateList&      layer,
+bool NeutralAtomLayer::commutesWithAtQubit(const GateList& layer,
                                            const qc::Operation* opPointer,
-                                           const qc::Qubit&     qubit) {
+                                           const qc::Qubit& qubit) {
   return std::all_of(layer.begin(), layer.end(),
                      [&opPointer, &qubit](const auto& frontOpPointer) {
                        return commuteAtQubit(opPointer, frontOpPointer, qubit);
@@ -161,7 +161,7 @@ bool NeutralAtomLayer::commutesWithAtQubit(const GateList&      layer,
 
 bool NeutralAtomLayer::commuteAtQubit(const qc::Operation* op1,
                                       const qc::Operation* op2,
-                                      const qc::Qubit&     qubit) {
+                                      const qc::Qubit& qubit) {
   if (op1->isNonUnitaryOperation() || op2->isNonUnitaryOperation()) {
     return false;
   }

--- a/src/hybridmap/NeutralAtomScheduler.cpp
+++ b/src/hybridmap/NeutralAtomScheduler.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 na::SchedulerResults
-na::NeutralAtomScheduler::schedule(const qc::QuantumComputation&     qc,
+na::NeutralAtomScheduler::schedule(const qc::QuantumComputation& qc,
                                    const std::map<HwQubit, HwQubit>& initHwPos,
                                    bool verbose, bool createAnimationCsv,
                                    qc::fp shuttlingSpeedFactor) {
@@ -38,8 +38,8 @@ na::NeutralAtomScheduler::schedule(const qc::QuantumComputation&     qc,
   // saves for each coord the time slots that are blocked by a multi qubit gate
   std::vector<std::deque<std::pair<qc::fp, qc::fp>>> rydbergBlockedQubitsTimes(
       arch.getNpositions(), std::deque<std::pair<qc::fp, qc::fp>>());
-  qc::fp aodLastBlockedTime  = 0;
-  qc::fp totalGateTime       = 0;
+  qc::fp aodLastBlockedTime = 0;
+  qc::fp totalGateTime = 0;
   qc::fp totalGateFidelities = 1;
 
   AnimationAtoms animationAtoms(initHwPos, arch);
@@ -48,9 +48,9 @@ na::NeutralAtomScheduler::schedule(const qc::QuantumComputation&     qc,
     animationArchitectureCsv = arch.getAnimationCsv();
   }
 
-  int      index        = 0;
-  int      nAodActivate = 0;
-  uint32_t nCZs         = 0;
+  int index = 0;
+  int nAodActivate = 0;
+  uint32_t nCZs = 0;
   for (const auto& op : qc) {
     index++;
     if (verbose) {
@@ -105,7 +105,7 @@ na::NeutralAtomScheduler::schedule(const qc::QuantumComputation&     qc,
           // check if qubit is blocked at maxTime
           for (const auto& startEnd : rydbergBlockedQubitsTimes[qubit]) {
             auto start = startEnd.first;
-            auto end   = startEnd.second;
+            auto end = startEnd.second;
             if ((start <= maxTime && end > maxTime) ||
                 (start <= maxTime + opTime && end > maxTime + opTime)) {
               rydbergBlocked = true;
@@ -194,7 +194,7 @@ void na::NeutralAtomScheduler::printSchedulerResults(
 }
 
 void na::NeutralAtomScheduler::printTotalExecutionTimes(
-    std::vector<qc::fp>&                                totalExecutionTimes,
+    std::vector<qc::fp>& totalExecutionTimes,
     std::vector<std::deque<std::pair<qc::fp, qc::fp>>>& blockedQubitsTimes) {
   std::cout << "ExecutionTime: "
             << "\n";

--- a/src/hybridmap/NeutralAtomUtils.cpp
+++ b/src/hybridmap/NeutralAtomUtils.cpp
@@ -16,14 +16,14 @@ namespace na {
 
 bool MoveVector::overlap(const MoveVector& other) const {
   // do not consider direction for overlap
-  const auto firstStartX  = std::min(xStart, xEnd);
-  const auto firstEndX    = std::max(xStart, xEnd);
+  const auto firstStartX = std::min(xStart, xEnd);
+  const auto firstEndX = std::max(xStart, xEnd);
   const auto secondStartX = std::min(other.xStart, other.xEnd);
-  const auto secondEndX   = std::max(other.xStart, other.xEnd);
-  const auto firstStartY  = std::min(yStart, yEnd);
-  const auto firstEndY    = std::max(yStart, yEnd);
+  const auto secondEndX = std::max(other.xStart, other.xEnd);
+  const auto firstStartY = std::min(yStart, yEnd);
+  const auto firstEndY = std::max(yStart, yEnd);
   const auto secondStartY = std::min(other.yStart, other.yEnd);
-  const auto secondEndY   = std::max(other.yStart, other.yEnd);
+  const auto secondEndY = std::max(other.yStart, other.yEnd);
 
   // need to compute all combinations, as sometimes the start and end x/y points
   // are the same
@@ -46,14 +46,14 @@ bool MoveVector::overlap(const MoveVector& other) const {
 }
 
 bool MoveVector::include(const MoveVector& other) const {
-  const auto firstStartX  = std::min(xStart, xEnd);
-  const auto firstEndX    = std::max(xStart, xEnd);
+  const auto firstStartX = std::min(xStart, xEnd);
+  const auto firstEndX = std::max(xStart, xEnd);
   const auto secondStartX = std::min(other.xStart, other.xEnd);
-  const auto secondEndX   = std::max(other.xStart, other.xEnd);
-  const auto firstStartY  = std::min(yStart, yEnd);
-  const auto firstEndY    = std::max(yStart, yEnd);
+  const auto secondEndX = std::max(other.xStart, other.xEnd);
+  const auto firstStartY = std::min(yStart, yEnd);
+  const auto firstEndY = std::max(yStart, yEnd);
   const auto secondStartY = std::min(other.yStart, other.yEnd);
-  const auto secondEndY   = std::max(other.yStart, other.yEnd);
+  const auto secondEndY = std::max(other.yStart, other.yEnd);
 
   const auto includeX =
       (secondStartX < firstStartX) && (firstEndX < secondEndX);

--- a/src/logicblocks/Encodings.cpp
+++ b/src/logicblocks/Encodings.cpp
@@ -4,10 +4,12 @@
 #include "LogicBlock.hpp"
 #include "LogicTerm.hpp"
 
-#include <map>
-#include <set>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace encodings {

--- a/src/logicblocks/Encodings.cpp
+++ b/src/logicblocks/Encodings.cpp
@@ -35,11 +35,11 @@ LogicTerm naiveAtMostOne(const std::vector<LogicTerm>& clauseVars) {
 }
 
 LogicTerm atMostOneBiMander(const std::vector<LogicTerm>& vars,
-                            LogicBlock*                   logic) {
-  auto                   subords = groupVarsBimander(vars, vars.size() / 2);
-  LogicTerm              ret     = LogicTerm(true);
+                            LogicBlock* logic) {
+  auto subords = groupVarsBimander(vars, vars.size() / 2);
+  LogicTerm ret = LogicTerm(true);
   std::vector<LogicTerm> binaryVars{};
-  auto                   m = subords.size();
+  auto m = subords.size();
   binaryVars.reserve(static_cast<size_t>(std::ceil(std::log2(m))));
   for (int32_t j = 0; j < std::ceil(std::log2(m)); j++) {
     binaryVars.emplace_back(
@@ -66,7 +66,7 @@ LogicTerm atMostOneBiMander(const std::vector<LogicTerm>& vars,
 
 LogicTerm exactlyOneCmdr(const std::vector<NestedVar>& subords,
                          const LogicTerm& cmdrVar, LogicBlock* logic) {
-  auto                   ret = LogicTerm(true);
+  auto ret = LogicTerm(true);
   std::vector<LogicTerm> clauseVars{};
   clauseVars.reserve(subords.size());
   for (const auto& it : subords) {
@@ -86,7 +86,7 @@ LogicTerm exactlyOneCmdr(const std::vector<NestedVar>& subords,
 
 LogicTerm atMostOneCmdr(const std::vector<NestedVar>& subords,
                         const LogicTerm& cmdrVar, LogicBlock* logic) {
-  auto                   ret = LogicTerm(true);
+  auto ret = LogicTerm(true);
   std::vector<LogicTerm> clauseVars;
   clauseVars.reserve(subords.size());
   for (const auto& it : subords) {
@@ -105,7 +105,7 @@ LogicTerm atMostOneCmdr(const std::vector<NestedVar>& subords,
 }
 
 std::vector<NestedVar> groupVars(const std::vector<LogicTerm>& vars,
-                                 std::size_t                   maxSize) {
+                                 std::size_t maxSize) {
   std::vector<NestedVar> vVars;
   vVars.reserve(vars.size());
   for (const auto& var : vars) {
@@ -118,13 +118,13 @@ std::vector<NestedVar> groupVars(const std::vector<LogicTerm>& vars,
 }
 
 std::vector<NestedVar> groupVarsAux(const std::vector<NestedVar>& vars,
-                                    std::size_t                   maxSize) {
+                                    std::size_t maxSize) {
   auto numVars = vars.size();
   if (numVars <= maxSize) {
     return vars;
   }
   std::vector<NestedVar> ret{};
-  const std::size_t      numGr = numVars / maxSize;
+  const std::size_t numGr = numVars / maxSize;
   ret.reserve(numGr);
   auto to = vars.begin();
   for (std::size_t i = 0U; i < numGr; i++) {
@@ -142,12 +142,12 @@ std::vector<NestedVar> groupVarsAux(const std::vector<NestedVar>& vars,
 std::vector<std::vector<LogicTerm>>
 groupVarsBimander(const std::vector<LogicTerm>& vars, std::size_t groupCount) {
   std::vector<std::vector<LogicTerm>> result{};
-  auto                                chunkSize = vars.size() / groupCount;
+  auto chunkSize = vars.size() / groupCount;
 
   for (size_t i = 0U; i < vars.size(); i += chunkSize) {
     auto from = vars.begin();
     std::advance(from, static_cast<int64_t>(i));
-    auto to  = vars.begin();
+    auto to = vars.begin();
     auto end = std::min(vars.size(), i + chunkSize);
     std::advance(to, static_cast<int64_t>(end));
     result.emplace_back(from, to);

--- a/src/logicblocks/LogicBlock.cpp
+++ b/src/logicblocks/LogicBlock.cpp
@@ -2,7 +2,7 @@
 
 #include "Logic.hpp"
 #include "LogicTerm.hpp"
-#include "Z3Model.hpp"
+#include "Z3Model.hpp" // IWYU pragma: keep
 
 #include <cstdint>
 #include <stdexcept>

--- a/src/logicblocks/LogicTerm.cpp
+++ b/src/logicblocks/LogicTerm.cpp
@@ -2,7 +2,9 @@
 
 #include "Logic.hpp"
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <initializer_list>
 #include <limits>

--- a/src/logicblocks/Z3Logic.cpp
+++ b/src/logicblocks/Z3Logic.cpp
@@ -3,12 +3,13 @@
 #include "Logic.hpp"
 #include "LogicTerm.hpp"
 #include "Z3Model.hpp"
-#include "plog/Log.h"
 
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <plog/Log.h>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -209,6 +210,7 @@ Result Z3LogicBlock::solve() {
   produceInstance();
   const auto res = solver->check();
   if (res == z3::sat) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     model = new Z3Model(ctx, std::make_shared<z3::model>(solver->get_model()));
     return Result::SAT;
   }
@@ -440,6 +442,7 @@ Result Z3LogicOptimizer::solve() {
   produceInstance();
   const auto res = optimizer->check();
   if (res == z3::sat) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     model =
         new Z3Model(ctx, std::make_shared<z3::model>(optimizer->get_model()));
     return Result::SAT;

--- a/src/logicblocks/Z3Logic.cpp
+++ b/src/logicblocks/Z3Logic.cpp
@@ -71,8 +71,8 @@ z3::expr Z3Base::convert(const LogicTerm& a, CType toType) {
   } break;
 
   case OpType::AND: {
-    z3::expr s         = this->ctx->bool_val(true);
-    bool     alternate = false;
+    z3::expr s = this->ctx->bool_val(true);
+    bool alternate = false;
     for (const LogicTerm& lt : a.getNodes()) {
       if (alternate) {
         s = s && convert(lt, toType);
@@ -84,8 +84,8 @@ z3::expr Z3Base::convert(const LogicTerm& a, CType toType) {
     v[static_cast<size_t>(toType)].second = s.simplify();
   } break;
   case OpType::OR: {
-    z3::expr s         = this->ctx->bool_val(false);
-    bool     alternate = false;
+    z3::expr s = this->ctx->bool_val(false);
+    bool alternate = false;
     for (const LogicTerm& lt : a.getNodes()) {
       if (alternate) {
         s = s || convert(lt, toType);
@@ -316,7 +316,7 @@ z3::expr Z3Base::convertVariableFromRealTo(const LogicTerm& a, CType toType) {
   }
 }
 z3::expr Z3Base::convertVariableFromBitvectorTo(const LogicTerm& a,
-                                                CType            toType) {
+                                                CType toType) {
   std::stringstream ss;
   ss << a.getName() << "_" << a.getID();
   switch (toType) {

--- a/src/logicblocks/Z3Model.cpp
+++ b/src/logicblocks/Z3Model.cpp
@@ -1,7 +1,11 @@
 #include "Z3Model.hpp"
 
+#include "LogicBlock.hpp"
+#include "LogicTerm.hpp"
 #include "Z3Logic.hpp"
 
+#include <cstdint>
+#include <string>
 #include <z3++.h>
 
 namespace z3logic {

--- a/src/na/Architecture.cpp
+++ b/src/na/Architecture.cpp
@@ -50,7 +50,7 @@ auto Architecture::fromFile(const std::string& jsonFn,
 
 auto Architecture::fromFileStream(std::istream& jsonS,
                                   std::istream& csvS) -> void {
-  nlohmann::json data;
+  nlohmann::basic_json data;
   // load CSV
   // auxiliary variables
   std::string line;

--- a/src/na/Architecture.cpp
+++ b/src/na/Architecture.cpp
@@ -60,8 +60,8 @@ auto Architecture::fromFileStream(std::istream& jsonS,
     while (csvS >> line) {
       ++lineno;
       std::stringstream lineStream(line); // make a stream of this line
-      std::string       sX;
-      std::string       sY;
+      std::string sX;
+      std::string sY;
 
       std::getline(lineStream, sX, ',');
       std::getline(lineStream, sY);
@@ -99,17 +99,17 @@ auto Architecture::fromFileStream(std::istream& jsonS,
       initialZones.emplace_back(nameToZone.find(zone)->second);
     }
     for (auto const& op : data["operations"]) {
-      const std::string        opName = op["name"];
-      const FullOpType         ty     = {qc::opTypeFromString(opName),
-                                         opName.find_first_not_of('c')};
-      const Scope              sc     = getScopeOfString(op["type"]);
-      std::unordered_set<Zone> zo     = {};
+      const std::string opName = op["name"];
+      const FullOpType ty = {qc::opTypeFromString(opName),
+                             opName.find_first_not_of('c')};
+      const Scope sc = getScopeOfString(op["type"]);
+      std::unordered_set<Zone> zo = {};
       for (auto const& zs : op["zones"]) {
         zo.emplace(nameToZone.find(zs)->second);
       }
-      const Value               fi = op["fidelity"];
-      const Value               ti = op["time"];
-      OperationProperties const o  = {sc, zo, ti, fi};
+      const Value fi = op["fidelity"];
+      const Value ti = op["time"];
+      OperationProperties const o = {sc, zo, ti, fi};
       gateSet.emplace(ty, o);
     }
     decoherenceTimes = {data["decoherence"]["t1"], data["decoherence"]["t2"]};
@@ -123,8 +123,8 @@ auto Architecture::fromFileStream(std::istream& jsonS,
           sh["store"]["time"], sh["store"]["fidelity"]};
       shuttling.emplace_back(sp);
     }
-    minAtomDistance     = data["minAtomDistance"];
-    interactionRadius   = data["interactionRadius"];
+    minAtomDistance = data["minAtomDistance"];
+    interactionRadius = data["interactionRadius"];
     noInteractionRadius = data["noInteractionRadius"];
   } catch (std::exception& e) {
     throw std::runtime_error(
@@ -152,18 +152,18 @@ auto Architecture::isAllowedLocally(const FullOpType& t) const -> bool {
   return it != gateSet.end() && it->second.scope == Scope::Local;
 }
 auto Architecture::isAllowedLocally(const FullOpType& t,
-                                    const Zone&       zone) const -> bool {
+                                    const Zone& zone) const -> bool {
   if (!isAllowedLocally(t)) {
     return false; // gate not supported at all
   }
-  const auto  it        = gateSet.find(t);
+  const auto it = gateSet.find(t);
   const auto& gateZones = it->second.zones;
   // zone exists in gateZones
   return gateZones.find(zone) != gateZones.end();
 }
 
 auto Architecture::isAllowedLocallyAt(const FullOpType& t,
-                                      const Point&      p) const -> bool {
+                                      const Point& p) const -> bool {
   const auto& it =
       std::find_if(zones.cbegin(), zones.cend(), [&](const auto& zProp) {
         return p.x >= zProp.minX && p.x <= zProp.maxX && p.y >= zProp.minY &&
@@ -184,11 +184,11 @@ auto Architecture::isAllowedGlobally(const FullOpType& t) const -> bool {
 }
 
 auto Architecture::isAllowedGlobally(const FullOpType& t,
-                                     const Zone&       zone) const -> bool {
+                                     const Zone& zone) const -> bool {
   if (!isAllowedGlobally(t)) {
     return false; // gate not supported at all
   }
-  const auto  it        = gateSet.find(t);
+  const auto it = gateSet.find(t);
   const auto& gateZones = it->second.zones;
   // zone exists in gateZones
   return gateZones.find(zone) != gateZones.end();
@@ -220,9 +220,9 @@ auto Architecture::getColsInZone(const Zone& z) const -> std::vector<Number> {
 auto Architecture::getNrowsInZone(const Zone& z) const -> Index {
   return Architecture::getRowsInZone(z).size();
 }
-auto Architecture::getSitesInRow(const Zone&  z,
+auto Architecture::getSitesInRow(const Zone& z,
                                  const Index& row) const -> std::vector<Index> {
-  const auto         y = Architecture::getRowsInZone(z)[row];
+  const auto y = Architecture::getRowsInZone(z)[row];
   std::vector<Index> atoms;
   for (Index i = 0; i < sites.size(); ++i) {
     const auto& s = sites[i];
@@ -357,7 +357,7 @@ auto Architecture::getNearestSiteDown(const Point& p, const bool proper,
 auto Architecture::getNearestSiteUpRight(const Point& p, const bool proper,
                                          const bool sameZone) const
     -> std::optional<Index> {
-  const auto&          zone = getZoneAt(p);
+  const auto& zone = getZoneAt(p);
   std::optional<Index> opt;
   for (std::size_t i = 0; i < sites.size(); ++i) {
     const auto& s = sites[i];
@@ -373,7 +373,7 @@ auto Architecture::getNearestSiteUpRight(const Point& p, const bool proper,
 auto Architecture::getNearestSiteUpLeft(const Point& p, const bool proper,
                                         const bool sameZone) const
     -> std::optional<Index> {
-  const auto&          zone = getZoneAt(p);
+  const auto& zone = getZoneAt(p);
   std::optional<Index> opt;
   for (std::size_t i = 0; i < sites.size(); ++i) {
     const auto& s = sites[i];
@@ -389,7 +389,7 @@ auto Architecture::getNearestSiteUpLeft(const Point& p, const bool proper,
 auto Architecture::getNearestSiteDownLeft(const Point& p, const bool proper,
                                           const bool sameZone) const
     -> std::optional<Index> {
-  const auto&          zone = getZoneAt(p);
+  const auto& zone = getZoneAt(p);
   std::optional<Index> opt;
   for (std::size_t i = 0; i < sites.size(); ++i) {
     const auto& s = sites[i];
@@ -405,7 +405,7 @@ auto Architecture::getNearestSiteDownLeft(const Point& p, const bool proper,
 auto Architecture::getNearestSiteDownRight(const Point& p, const bool proper,
                                            const bool sameZone) const
     -> std::optional<Index> {
-  const auto&          zone = getZoneAt(p);
+  const auto& zone = getZoneAt(p);
   std::optional<Index> opt;
   for (std::size_t i = 0; i < sites.size(); ++i) {
     const auto& s = sites[i];
@@ -440,7 +440,7 @@ auto Architecture::withConfig(const Configuration& config) const
         if (!usedSites[i]) {
           // s is not used yet
           bool patchFittable = true;
-          auto row           = i;
+          auto row = i;
           for (std::size_t r = 1; r < config.getPatchRows(); ++r) {
             auto col = row;
             for (std::size_t c = 1; c < config.getPatchCols(); ++c) {
@@ -534,11 +534,11 @@ auto Architecture::getPositionOffsetBy(const Point& p, const Number& rows,
 
   // get position of nearest site
   const auto nearestSitePos = getPositionOfSite(nearestSiteOpt.value());
-  const auto dx             = p.x - nearestSitePos.x;
-  const auto dy             = p.y - nearestSitePos.y;
-  auto       anchorSitePos  = nearestSitePos;
-  auto       r              = std::abs(rows);
-  auto       c              = std::abs(cols);
+  const auto dx = p.x - nearestSitePos.x;
+  const auto dy = p.y - nearestSitePos.y;
+  auto anchorSitePos = nearestSitePos;
+  auto r = std::abs(rows);
+  auto c = std::abs(cols);
 
   for (; r > 0; --r) {
     auto nextSiteOpt = rows >= 0 ? getNearestSiteDown(anchorSitePos, true, true)

--- a/src/na/Configuration.cpp
+++ b/src/na/Configuration.cpp
@@ -6,12 +6,15 @@
 
 #include "Configuration.hpp"
 
+#include <exception>
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 
-using json = nlohmann::json;
+using json = nlohmann::basic_json<>;
 
 namespace na {
 
@@ -31,7 +34,7 @@ Configuration::Configuration(std::istream& fs) {
     fs >> data;
   } catch (const std::exception& e) {
     std::stringstream ss;
-    ss << "Error parsing JSON: " << e.what() << std::endl;
+    ss << "Error parsing JSON: " << e.what() << '\n';
     throw std::runtime_error(ss.str());
   }
 

--- a/src/na/NAGraphAlgorithms.cpp
+++ b/src/na/NAGraphAlgorithms.cpp
@@ -30,8 +30,8 @@ namespace na {
 auto NAGraphAlgorithms::getMaxIndependentSet(const InteractionGraph& g)
     -> std::unordered_set<qc::Qubit> {
   std::unordered_set<qc::Qubit> result;
-  const auto&                   vertices = g.getVertices();
-  std::list<qc::Qubit>          queue(vertices.cbegin(), vertices.cend());
+  const auto& vertices = g.getVertices();
+  std::list<qc::Qubit> queue(vertices.cbegin(), vertices.cend());
   // sort the vertices by degree in descending order
   queue.sort([&](const auto& u, const auto& v) {
     return g.getDegree(u) > g.getDegree(v);
@@ -45,7 +45,7 @@ auto NAGraphAlgorithms::getMaxIndependentSet(const InteractionGraph& g)
   return result;
 }
 
-auto NAGraphAlgorithms::coveredEdges(const InteractionGraph&              g,
+auto NAGraphAlgorithms::coveredEdges(const InteractionGraph& g,
                                      const std::unordered_set<qc::Qubit>& vs)
     -> std::unordered_set<Edge, qc::PairHash<qc::Qubit, qc::Qubit>> {
   std::unordered_set<Edge, qc::PairHash<qc::Qubit, qc::Qubit>> result;
@@ -65,10 +65,10 @@ auto NAGraphAlgorithms::coveredEdges(const InteractionGraph&              g,
 
 auto NAGraphAlgorithms::getLeastAdmissibleColor(
     const std::unordered_map<Edge, Color, qc::PairHash<qc::Qubit, qc::Qubit>>&
-                 coloring,
+        coloring,
     const Color& maxColor, const Edge& e, const qc::Qubit& v,
-    const std::vector<qc::Qubit>&                             sequence,
-    const qc::DirectedAcyclicGraph<qc::Qubit>&                partialOrder,
+    const std::vector<qc::Qubit>& sequence,
+    const qc::DirectedAcyclicGraph<qc::Qubit>& partialOrder,
     const std::unordered_map<std::pair<qc::Qubit, Color>, std::size_t,
                              qc::PairHash<qc::Qubit, Color>>& ranks) -> Color {
   // compute the minimum admissible color as the maximum color +1 of adjacent
@@ -142,14 +142,14 @@ auto NAGraphAlgorithms::getLeastAdmissibleColor(
 }
 
 auto NAGraphAlgorithms::colorEdges(
-    const InteractionGraph&                                             g,
+    const InteractionGraph& g,
     const std::unordered_set<Edge, qc::PairHash<qc::Qubit, qc::Qubit>>& edges,
     const std::vector<qc::Qubit>& nodesQueue)
     -> std::pair<
         std::unordered_map<Edge, Color, qc::PairHash<qc::Qubit, qc::Qubit>>,
         qc::DirectedAcyclicGraph<qc::Qubit>> {
   std::unordered_map<Edge, Color, qc::PairHash<qc::Qubit, qc::Qubit>>
-        coloring{};
+      coloring{};
   Color maxColor = 0;
   // number of distinct colors of edges adjacent to an edge
   std::unordered_map<Edge, std::size_t, qc::PairHash<qc::Qubit, qc::Qubit>>
@@ -230,7 +230,7 @@ auto NAGraphAlgorithms::colorEdges(
       coloring[e] = getLeastAdmissibleColor(coloring, maxColor, e, v,
                                             nodesQueue, partialOrder, ranks);
       // update partial order
-      const qc::Qubit u       = e.first == v ? e.second : e.first;
+      const qc::Qubit u = e.first == v ? e.second : e.first;
       ranks[{u, coloring[e]}] = static_cast<std::size_t>(
           std::distance(nodesQueue.cbegin(),
                         std::find(nodesQueue.cbegin(), nodesQueue.cend(), v)));
@@ -334,7 +334,7 @@ auto NAGraphAlgorithms::computeRestingPositions(
       if (moveableXs.find(v) == moveableXs.end()) {
         // index of v in moveable
         const auto& it = std::find(moveable.cbegin(), moveable.cend(), v);
-        const auto  i =
+        const auto i =
             static_cast<std::size_t>(std::distance(moveable.cbegin(), it));
         // get the index of the left neighbor in the keys of moveableXs
         std::vector<std::size_t> leftNeighbors;
@@ -434,9 +434,9 @@ auto NAGraphAlgorithms::computeRestingPositions(
 }
 
 auto NAGraphAlgorithms::groupByConnectedComponent(
-    const InteractionGraph&       g,
+    const InteractionGraph& g,
     const std::vector<qc::Qubit>& sequence) -> std::vector<qc::Qubit> {
-  const auto&                vertices = g.getVertices();
+  const auto& vertices = g.getVertices();
   qc::DisjointSet<qc::Qubit> ds(vertices.cbegin(), vertices.cend());
   for (const qc::Qubit& v : vertices) {
     for (const qc::Qubit& u : vertices) {
@@ -459,7 +459,7 @@ auto NAGraphAlgorithms::groupByConnectedComponent(
 }
 
 auto NAGraphAlgorithms::computeSequence(const InteractionGraph& g,
-                                        const std::size_t       maxSites)
+                                        const std::size_t maxSites)
     -> std::pair<std::vector<std::unordered_map<qc::Qubit, std::int64_t>>,
                  std::unordered_map<qc::Qubit, std::int64_t>> {
   const auto& maxIndepSet = getMaxIndependentSet(g);
@@ -469,13 +469,13 @@ auto NAGraphAlgorithms::computeSequence(const InteractionGraph& g,
             [&](const auto& u, const auto& v) {
               return g.getDegree(u) > g.getDegree(v);
             });
-  auto        sequence = groupByConnectedComponent(g, sequenceUngrouped);
+  auto sequence = groupByConnectedComponent(g, sequenceUngrouped);
   const auto& colorEdgesResult =
       colorEdges(g, coveredEdges(g, maxIndepSet), sequence);
-  auto coloring     = colorEdgesResult.first;
+  auto coloring = colorEdgesResult.first;
   auto partialOrder = colorEdgesResult.second;
-  auto fixed        = partialOrder.orderTopologically();
-  auto resting      = computeRestingPositions(sequence, fixed, coloring);
+  auto fixed = partialOrder.orderTopologically();
+  auto resting = computeRestingPositions(sequence, fixed, coloring);
   // compute relative x positions of fixed vertices
   std::unordered_map<qc::Qubit, std::int64_t> fixedPositions{};
   for (std::uint32_t x = 0, i = 0; x < fixed.size(); ++x) {
@@ -591,7 +591,7 @@ auto NAGraphAlgorithms::computeSequence(const InteractionGraph& g,
               moveablePositions.at(t).cbegin(), moveablePositions.at(t).cend(),
               std::make_pair(0UL, 0LL),
               [](const std::pair<const qc::Qubit, std::int64_t>& acc,
-                 const auto&                                     value) {
+                 const auto& value) {
                 if (value.second > acc.second) {
                   return value;
                 }
@@ -599,9 +599,9 @@ auto NAGraphAlgorithms::computeSequence(const InteractionGraph& g,
               });
           // k is the number of spots between the left positioned neighbor and
           // the leftmost atom (including itself)
-          const auto         k = static_cast<std::size_t>(std::distance(
+          const auto k = static_cast<std::size_t>(std::distance(
               sequence.cbegin(), std::find(sequence.cbegin(), sequence.cend(),
-                                                   leftNeighbor.first)));
+                                           leftNeighbor.first)));
           const std::int64_t maxX =
               std::accumulate(fixedPositions.cbegin(), fixedPositions.cend(),
                               static_cast<std::int64_t>(0),

--- a/src/na/NAMapper.cpp
+++ b/src/na/NAMapper.cpp
@@ -103,7 +103,7 @@ auto NAMapper::makeLogicalArrays() -> void {
     if (op->isGlobalOperation()) {
       mappedQc.emplaceBack(op->clone());
     } else if (op->isLocalOperation()) {
-      const auto& lop          = dynamic_cast<NALocalOperation&>(*op);
+      const auto& lop = dynamic_cast<NALocalOperation&>(*op);
       const auto& allPositions = lop.getPositions();
       const auto& posPerRow =
           std::accumulate(allPositions.cbegin(), allPositions.cend(),
@@ -127,9 +127,9 @@ auto NAMapper::makeLogicalArrays() -> void {
         }
       }
     } else if (op->isShuttlingOperation()) {
-      const auto& sop           = dynamic_cast<NAShuttlingOperation&>(*op);
-      const auto  shuttlingSize = sop.getStart().size();
-      const auto  pointCount =
+      const auto& sop = dynamic_cast<NAShuttlingOperation&>(*op);
+      const auto shuttlingSize = sop.getStart().size();
+      const auto pointCount =
           shuttlingSize * static_cast<std::size_t>(rows * cols);
       std::vector<std::shared_ptr<Point>> start;
       start.reserve(pointCount);
@@ -189,12 +189,12 @@ auto NAMapper::calculateMovements() -> void {
         std::vector<std::shared_ptr<Point>> hMoveEnd;
         std::vector<std::shared_ptr<Point>> vOffsetStart;
         std::vector<std::shared_ptr<Point>> vOffsetEnd;
-        bool                                vOffset = false;
+        bool vOffset = false;
         for (std::size_t i = 0; i < shuttlingOp.getStart().size(); ++i) {
-          const auto  start = *shuttlingOp.getStart()[i];
-          const auto  end   = *shuttlingOp.getEnd()[i];
-          const auto  dx    = end.x - start.x;
-          Point const mid   = {start.x, end.y};
+          const auto start = *shuttlingOp.getStart()[i];
+          const auto end = *shuttlingOp.getEnd()[i];
+          const auto dx = end.x - start.x;
+          Point const mid = {start.x, end.y};
           if (dx > 0) {
             if (const auto s = arch.getNearestSiteRight(mid, true)) {
               if (arch.getPositionOfSite(*s).x < end.x) {
@@ -214,10 +214,10 @@ auto NAMapper::calculateMovements() -> void {
           }
         }
         for (std::size_t i = 0; i < shuttlingOp.getStart().size(); ++i) {
-          auto       start = *shuttlingOp.getStart()[i];
-          auto       end   = *shuttlingOp.getEnd()[i];
-          const auto dx    = end.x - start.x;
-          const auto dy    = end.y - start.y;
+          auto start = *shuttlingOp.getStart()[i];
+          auto end = *shuttlingOp.getEnd()[i];
+          const auto dx = end.x - start.x;
+          const auto dy = end.y - start.y;
           if (dy > 0) {
             if (const auto s = arch.getNearestSiteDown(start, true)) {
               if (arch.getPositionOfSite(*s).y < end.y) {
@@ -324,7 +324,7 @@ auto NAMapper::checkApplicability(
 }
 
 auto NAMapper::updatePlacement(const qc::Operation* op,
-                               std::vector<Atom>&   placement) const -> void {
+                               std::vector<Atom>& placement) const -> void {
   if (op->isCompoundOperation()) {
     // global gates are represented as compound operations
     return;
@@ -354,7 +354,7 @@ auto NAMapper::updatePlacement(const qc::Operation* op,
                 });
 }
 
-auto NAMapper::getMisplacement(const std::vector<Atom>&      initial,
+auto NAMapper::getMisplacement(const std::vector<Atom>& initial,
                                const std::vector<qc::Qubit>& target,
                                const qc::Qubit& q) -> std::int64_t {
   if (initial.at(q).positionStatus == Atom::PositionStatus::UNDEFINED) {
@@ -362,7 +362,7 @@ auto NAMapper::getMisplacement(const std::vector<Atom>&      initial,
   }
 
   std::int64_t misplacement = 0;
-  const auto   indexOfQ     = static_cast<std::size_t>(std::distance(
+  const auto indexOfQ = static_cast<std::size_t>(std::distance(
       target.cbegin(), std::find(target.cbegin(), target.cend(), q)));
 
   for (std::size_t i = 0; i < target.size(); ++i) {
@@ -390,15 +390,15 @@ auto NAMapper::getMisplacement(const std::vector<Atom>&      initial,
   return misplacement + static_cast<std::int64_t>(indexOfQ);
 }
 
-auto NAMapper::store(std::vector<bool>&             initialFreeSites,
-                     std::vector<bool>&             currentFreeSites,
-                     std::vector<Atom>&             placement,
+auto NAMapper::store(std::vector<bool>& initialFreeSites,
+                     std::vector<bool>& currentFreeSites,
+                     std::vector<Atom>& placement,
                      std::unordered_set<qc::Qubit>& currentlyShuttling,
-                     const std::vector<qc::Qubit>&  qubits,
-                     const Zone                     destination) -> void {
+                     const std::vector<qc::Qubit>& qubits,
+                     const Zone destination) -> void {
   // this distance is used for spacing atoms that should interact or pass
   // another atom
-  const auto d  = static_cast<std::int64_t>(arch.getMinAtomDistance());
+  const auto d = static_cast<std::int64_t>(arch.getMinAtomDistance());
   const auto dx = static_cast<std::int64_t>(config.getPatchCols()) *
                   static_cast<std::int64_t>(arch.getNoInteractionRadius());
   { // load atoms that are not already shuttling
@@ -439,7 +439,7 @@ auto NAMapper::store(std::vector<bool>&             initialFreeSites,
             });
   std::size_t moveableSpotsNeeded = qubits.size();
   std::vector<std::tuple<Index, std::size_t>> moveableSelectedRows;
-  std::size_t                                 firstIWithSameN = 0;
+  std::size_t firstIWithSameN = 0;
   for (std::size_t i = 0; i < freeSitesPerRow.size(); ++i) {
     const auto [r, n] = freeSitesPerRow[i];
     if (n >= moveableSpotsNeeded) {
@@ -469,10 +469,10 @@ auto NAMapper::store(std::vector<bool>&             initialFreeSites,
     std::vector<std::shared_ptr<Point>> end;
     std::vector<std::shared_ptr<Point>> storeStart;
     std::vector<std::shared_ptr<Point>> storeEnd;
-    std::size_t                         notStoredLeft = 0;
-    std::size_t                         j             = 0;
+    std::size_t notStoredLeft = 0;
+    std::size_t j = 0;
     const auto& sitesInRow = arch.getSitesInRow(destination, r);
-    const auto  y =
+    const auto y =
         arch.getPositionOfSite(arch.getSitesInRow(destination, r).at(0)).y;
     for (const auto q : qubits) {
       if (currentlyShuttling.find(q) != currentlyShuttling.cend()) {
@@ -495,7 +495,7 @@ auto NAMapper::store(std::vector<bool>&             initialFreeSites,
           n -= 1;
         } else if (j < sitesInRow.size() &&
                    currentFreeSites.at(sitesInRow.at(j))) {
-          const auto& s    = sitesInRow.at(j);
+          const auto& s = sitesInRow.at(j);
           const auto& sPos = arch.getPositionOfSite(s);
           placement.at(q).currentPosition =
               std::make_shared<Point>(sPos.x + d, sPos.y);
@@ -509,7 +509,7 @@ auto NAMapper::store(std::vector<bool>&             initialFreeSites,
           initialFreeSites.at(s) = false;
           n -= 1;
         } else if (j < sitesInRow.size()) {
-          const auto& s    = sitesInRow.at(j);
+          const auto& s = sitesInRow.at(j);
           const auto& sPos = arch.getPositionOfSite(s);
           placement.at(q).currentPosition =
               std::make_shared<Point>(sPos.x + d, sPos.y);
@@ -530,14 +530,14 @@ auto NAMapper::store(std::vector<bool>&             initialFreeSites,
   }
 }
 
-auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
-                      std::vector<bool>&             currentFreeSites,
-                      std::vector<Atom>&             placement,
+auto NAMapper::pickUp(std::vector<bool>& initialFreeSites,
+                      std::vector<bool>& currentFreeSites,
+                      std::vector<Atom>& placement,
                       std::unordered_set<qc::Qubit>& currentlyShuttling,
-                      const std::vector<qc::Qubit>&  qubitsOrdered) -> void {
+                      const std::vector<qc::Qubit>& qubitsOrdered) -> void {
   // this distance is used for spacing atoms that should interact or pass
   // another atom
-  const auto d  = static_cast<std::int64_t>(arch.getMinAtomDistance());
+  const auto d = static_cast<std::int64_t>(arch.getMinAtomDistance());
   const auto dx = static_cast<std::int64_t>(config.getPatchCols()) *
                   static_cast<std::int64_t>(arch.getNoInteractionRadius());
   // get a vector of the atoms in the order to pick them up based on
@@ -573,9 +573,9 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
           ++notPickedUpLeft;
         }
       }
-      const auto  spotsNeeded    = pickUpOrder.size();
-      Zone        zone           = 0;
-      Index       row            = 0;
+      const auto spotsNeeded = pickUpOrder.size();
+      Zone zone = 0;
+      Index row = 0;
       std::size_t freeSpotsInRow = 0;
       for (const auto& z : placement.at(q).zones) {
         for (std::size_t r = 0; r < arch.getNrowsInZone(z); ++r) {
@@ -587,8 +587,8 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
                               });
           if (freeSpotsInRow <= spotsNeeded && n > freeSpotsInRow) {
             freeSpotsInRow = n;
-            zone           = z;
-            row            = r;
+            zone = z;
+            row = r;
           }
         }
       }
@@ -601,10 +601,10 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
           possibleSites.end());
       const auto s =
           possibleSites[std::min(notPickedUpLeft, freeSpotsInRow - 1)];
-      placement.at(q).positionStatus   = Atom::PositionStatus::DEFINED;
+      placement.at(q).positionStatus = Atom::PositionStatus::DEFINED;
       *placement.at(q).initialPosition = arch.getPositionOfSite(s);
-      initialFreeSites.at(s)           = false;
-      currentFreeSites.at(s)           = false;
+      initialFreeSites.at(s) = false;
+      currentFreeSites.at(s) = false;
     }
     // here the position of q is defined
     std::vector<std::shared_ptr<Point>> start;
@@ -612,7 +612,7 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
     std::vector<std::shared_ptr<Point>> loadStart;
     std::vector<std::shared_ptr<Point>> loadEnd;
     const auto currentX = placement.at(q).currentPosition->x;
-    const auto y        = placement.at(q).currentPosition->y;
+    const auto y = placement.at(q).currentPosition->y;
     // pick up q itself
     loadStart.emplace_back(placement.at(q).currentPosition);
     currentFreeSites.at(*arch.getSiteAt(*placement.at(q).currentPosition)) =
@@ -665,14 +665,14 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
             // be picked up together with q, i.e. find next free site to the
             // left
             std::int64_t freeX = x;
-            bool         free  = false;
+            bool free = false;
             while (!free) {
               const auto siteOpt = arch.getNearestSiteLeft({freeX, y});
               if (!siteOpt) {
                 break;
               }
               const auto site = *siteOpt;
-              freeX           = arch.getPositionOfSite(site).x;
+              freeX = arch.getPositionOfSite(site).x;
               if (initialFreeSites.at(site) &&
                   std::find(placement.at(p).zones.cbegin(),
                             placement.at(p).zones.cend(),
@@ -689,7 +689,7 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
             }
             if (free) {
               // place p on the free site
-              placement.at(p).positionStatus   = Atom::PositionStatus::DEFINED;
+              placement.at(p).positionStatus = Atom::PositionStatus::DEFINED;
               *placement.at(p).initialPosition = {freeX, y};
               initialFreeSites.at(
                   *arch.getSiteAt(*placement.at(p).initialPosition)) = false;
@@ -715,9 +715,9 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
     }
     // iterate through all not yet picked up atoms to the right and check
     // whether they can be picked up
-    x              = currentX + d;
+    x = currentX + d;
     const auto nx1 = arch.getNearestXRight(x, arch.getZoneAt({x, y}));
-    x              = nx1 == x ? x + dx : nx1 + d;
+    x = nx1 == x ? x + dx : nx1 + d;
     for (std::size_t j = i + 1; j < qubitsOrdered.size(); ++j) {
       const auto p = qubitsOrdered[j];
       // if the atom is picked up, move it to the correct row
@@ -726,7 +726,7 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
         placement.at(p).currentPosition = std::make_shared<Point>(x, y);
         end.emplace_back(placement.at(p).currentPosition);
         const auto nx = arch.getNearestXRight(x, arch.getZoneAt({x, y}));
-        x             = nx == x ? x + dx : nx + d;
+        x = nx == x ? x + dx : nx + d;
       } else {
         // check whether j can be picked up
         if (placement.at(p).positionStatus == Atom::PositionStatus::DEFINED) {
@@ -752,14 +752,14 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
           // be picked up together with q, i.e. find next free site to the
           // right
           std::int64_t freeX = x;
-          bool         free  = false;
+          bool free = false;
           while (!free) {
             const auto siteOpt = arch.getNearestSiteRight({freeX - d, y});
             if (!siteOpt) {
               break;
             }
             const auto site = *siteOpt;
-            freeX           = arch.getPositionOfSite(site).x;
+            freeX = arch.getPositionOfSite(site).x;
             if (initialFreeSites.at(site) &&
                 std::find(placement.at(p).zones.cbegin(),
                           placement.at(p).zones.cend(),
@@ -776,7 +776,7 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
           }
           if (free) {
             // place p on the free site
-            placement.at(p).positionStatus   = Atom::PositionStatus::DEFINED;
+            placement.at(p).positionStatus = Atom::PositionStatus::DEFINED;
             *placement.at(p).initialPosition = {freeX, y};
             initialFreeSites.at(
                 *arch.getSiteAt(*placement.at(p).initialPosition)) = false;
@@ -804,40 +804,40 @@ auto NAMapper::pickUp(std::vector<bool>&             initialFreeSites,
 }
 
 auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
-  auto startPreprocess    = std::chrono::high_resolution_clock::now();
-  initialQc               = qc;
-  const auto  nqubits     = initialQc.getNqubits();
+  auto startPreprocess = std::chrono::high_resolution_clock::now();
+  initialQc = qc;
+  const auto nqubits = initialQc.getNqubits();
   std::size_t maxSeqWidth = 0;
-  mappedQc                = NAComputation();
+  mappedQc = NAComputation();
   preprocess();
   // store the placement of atoms, both the initial one (needed later) and the
   // current one leave atoms unmapped as long as possible. This mighty induce
   // some restrictions on the mapping in which zone the atom may be placed.
-  const auto        initialZones = arch.getInitialZones();
+  const auto initialZones = arch.getInitialZones();
   std::vector<Atom> placement(nqubits);
   std::for_each(placement.begin(), placement.end(),
                 [&](auto& p) { p = Atom(initialZones); });
-  std::vector                   initialFreeSites(arch.getNSites(), true);
-  std::vector                   currentFreeSites(arch.getNSites(), true);
+  std::vector initialFreeSites(arch.getNSites(), true);
+  std::vector currentFreeSites(arch.getNSites(), true);
   std::unordered_set<qc::Qubit> currentlyShuttling{};
   // this distance is used for spacing atoms that should interact or pass
   // another atom
-  const auto d  = static_cast<std::int64_t>(arch.getMinAtomDistance());
+  const auto d = static_cast<std::int64_t>(arch.getMinAtomDistance());
   const auto dx = static_cast<std::int64_t>(config.getPatchCols()) *
                   static_cast<std::int64_t>(arch.getNoInteractionRadius());
   // get start time
   auto startMapping = std::chrono::high_resolution_clock::now();
   //============================ START MAPPING ============================
   const qc::Layer layer(initialQc);
-  const auto&     executableSet = layer.getExecutableSet();
-  auto            it            = executableSet.begin();
+  const auto& executableSet = layer.getExecutableSet();
+  auto it = executableSet.begin();
   if (config.getMethod() == NAMappingMethod::Naive) {
     for (qc::Qubit q = 0; q < nqubits; ++q) {
       placement.at(q).positionStatus = Atom::PositionStatus::DEFINED;
       const auto s = arch.getSitesInZone(initialZones.front()).at(q);
       *placement.at(q).initialPosition = arch.getPositionOfSite(s);
-      initialFreeSites.at(s)           = false;
-      currentFreeSites.at(s)           = false;
+      initialFreeSites.at(s) = false;
+      currentFreeSites.at(s) = false;
     }
   }
   while (it != executableSet.end()) {
@@ -900,10 +900,10 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
             "Other gates than cz are not supported for mapping yet.");
       }
       (*it)->execute();
-      const auto&  q1     = op->getTargets().front();
-      const auto&  q2     = op->getControls().begin()->qubit;
-      Point        start  = *placement.at(q1).currentPosition;
-      Point        end    = start;
+      const auto& q1 = op->getTargets().front();
+      const auto& q2 = op->getControls().begin()->qubit;
+      Point start = *placement.at(q1).currentPosition;
+      Point end = start;
       const Point& target = arch.getPositionOfSite(
           arch.getSitesInZone(*arch.getPropertiesOfOperation({op->getType(), 1})
                                    .zones.begin())
@@ -913,7 +913,7 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
           LOAD, std::vector{std::make_shared<Point>(start)},
           std::vector{std::make_shared<Point>(end)});
       start = end;
-      end   = target;
+      end = target;
       end.x += d;
       mappedQc.emplaceBack<NAShuttlingOperation>(
           MOVE, std::vector{std::make_shared<Point>(start)},
@@ -924,13 +924,13 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
           STORE, std::vector{std::make_shared<Point>(start)},
           std::vector{std::make_shared<Point>(end)});
       start = *placement.at(q2).currentPosition;
-      end   = start;
+      end = start;
       end.x += d;
       mappedQc.emplaceBack<NAShuttlingOperation>(
           LOAD, std::vector{std::make_shared<Point>(start)},
           std::vector{std::make_shared<Point>(end)});
       start = end;
-      end   = target;
+      end = target;
       end.y += d;
       mappedQc.emplaceBack<NAShuttlingOperation>(
           MOVE, std::vector{std::make_shared<Point>(start)},
@@ -945,13 +945,13 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
           STORE, std::vector{std::make_shared<Point>(start)},
           std::vector{std::make_shared<Point>(end)});
       start = target;
-      end   = start;
+      end = start;
       end.x += d;
       mappedQc.emplaceBack<NAShuttlingOperation>(
           LOAD, std::vector{std::make_shared<Point>(start)},
           std::vector{std::make_shared<Point>(end)});
       start = end;
-      end   = *placement.at(q1).currentPosition;
+      end = *placement.at(q1).currentPosition;
       end.x += d;
       mappedQc.emplaceBack<NAShuttlingOperation>(
           MOVE, std::vector{std::make_shared<Point>(start)},
@@ -971,11 +971,11 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
       }
       const Zone interactionZone =
           *arch.getPropertiesOfOperation({qc::OpType::Z, 1}).zones.begin();
-      const auto  sites = arch.getSitesInRow(interactionZone, 0);
+      const auto sites = arch.getSitesInRow(interactionZone, 0);
       const auto& sequence =
           NAGraphAlgorithms::computeSequence(graph, sites.size());
       const auto& moveable = sequence.first;
-      const auto& fixed    = sequence.second;
+      const auto& fixed = sequence.second;
       // 3. move the atoms accordingly and execute the gates
       // pick up the fixed atoms and move them to the interaction zone
       // get a vector of the fixed atoms ordered by their initial position
@@ -1027,7 +1027,7 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
         placement.at(q).currentPosition = std::make_shared<Point>(p.x + d, p.y);
         mid.emplace_back(placement.at(q).currentPosition);
         currentFreeSites.at(*arch.getSiteAt(p)) = false;
-        placement.at(q).currentPosition         = std::make_shared<Point>(p);
+        placement.at(q).currentPosition = std::make_shared<Point>(p);
         end.emplace_back(placement.at(q).currentPosition);
       }
       currentlyShuttling.clear();
@@ -1130,8 +1130,8 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
       const auto& freeSite =
           std::find_if(possibleSites.cbegin(), possibleSites.cend(),
                        [&](const auto& s) { return initialFreeSites.at(s); });
-      *p.initialPosition             = arch.getPositionOfSite(*freeSite);
-      p.positionStatus               = Atom::PositionStatus::DEFINED;
+      *p.initialPosition = arch.getPositionOfSite(*freeSite);
+      p.positionStatus = Atom::PositionStatus::DEFINED;
       initialFreeSites.at(*freeSite) = false;
       currentFreeSites.at(*freeSite) = false;
     }
@@ -1143,17 +1143,17 @@ auto NAMapper::map(const qc::QuantumComputation& qc) -> void {
   postprocess();
   auto end = std::chrono::high_resolution_clock::now();
   // build remaining statistics
-  stats.numInitialGates    = qc.getNops();
+  stats.numInitialGates = qc.getNops();
   stats.numEntanglingGates = static_cast<std::size_t>(
       std::count_if(qc.cbegin(), qc.cend(), [](const auto& op) {
         return (op->getType() == qc::OpType::Z &&
                 op->getType() == qc::OpType::X) ||
                op->getNcontrols() > 0;
       }));
-  stats.initialDepth   = qc.getDepth();
+  stats.initialDepth = qc.getDepth();
   stats.numMappedGates = mappedQc.size();
-  stats.numQubits      = nqubits;
-  stats.maxSeqWidth    = config.getPatchCols() * maxSeqWidth;
+  stats.numQubits = nqubits;
+  stats.maxSeqWidth = config.getPatchCols() * maxSeqWidth;
   // get the mapping time in milliseconds
   stats.preprocessTime =
       std::chrono::duration<qc::fp, std::milli>(startMapping - startPreprocess)

--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -672,7 +672,7 @@ PYBIND11_MODULE(pyqmap, m, py::mod_gil_not_used()) {
   quantumComputation.def_static(
       "from_qasm_str",
       [](const std::string& qasm) {
-        std::stringstream      ss(qasm);
+        std::stringstream ss(qasm);
         qc::QuantumComputation qc{};
         qc.import(ss, qc::Format::OpenQASM3);
         return qc;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -30,8 +30,8 @@ void Dijkstra::buildTable(const CouplingMap& couplingMap, Matrix& distanceTable,
     std::vector<Dijkstra::Node> nodes(n);
     for (std::uint16_t j = 0; j < n; ++j) {
       nodes.at(j).visited = false;
-      nodes.at(j).pos     = j;
-      nodes.at(j).cost    = -1.;
+      nodes.at(j).pos = j;
+      nodes.at(j).cost = -1.;
     }
 
     nodes.at(i).cost = 0;
@@ -54,7 +54,7 @@ void Dijkstra::dijkstra(const CouplingMap& couplingMap,
   std::priority_queue<Node*, std::vector<Node*>, NodeComparator> queue{};
   queue.push(&nodes.at(start));
   while (!queue.empty()) {
-    auto* current    = queue.top();
+    auto* current = queue.top();
     current->visited = true;
     queue.pop();
     auto pos = current->pos;
@@ -73,7 +73,7 @@ void Dijkstra::dijkstra(const CouplingMap& couplingMap,
 
         Node newNode;
         newNode.cost = current->cost + edgeWeights.at(*pos).at(*to);
-        newNode.pos  = to;
+        newNode.pos = to;
         if (nodes.at(*to).cost < 0 || newNode < nodes.at(*to)) {
           nodes.at(*to) = newNode;
           queue.push(&nodes.at(*to));
@@ -83,9 +83,9 @@ void Dijkstra::dijkstra(const CouplingMap& couplingMap,
   }
 }
 
-void Dijkstra::buildEdgeSkipTable(const CouplingMap&   couplingMap,
+void Dijkstra::buildEdgeSkipTable(const CouplingMap& couplingMap,
                                   std::vector<Matrix>& distanceTables,
-                                  const Matrix&        edgeWeights) {
+                                  const Matrix& edgeWeights) {
   /* to find the cheapest distance between 2 qubits skipping any 1 edge, we
   iterate over all edges, for each assume the current edge to be the one skipped
   and are thereby able to retrieve the distance by just adding the distances
@@ -139,9 +139,9 @@ void Dijkstra::buildEdgeSkipTable(const CouplingMap&   couplingMap,
   }
 }
 
-void Dijkstra::buildSingleEdgeSkipTable(const Matrix&      distanceTable,
+void Dijkstra::buildSingleEdgeSkipTable(const Matrix& distanceTable,
                                         const CouplingMap& couplingMap,
-                                        const double       reversalCost,
+                                        const double reversalCost,
                                         Matrix& edgeSkipDistanceTable) {
   const std::size_t n = distanceTable.size();
   edgeSkipDistanceTable.clear();
@@ -216,10 +216,10 @@ void dfs(std::uint16_t current, std::set<std::uint16_t>& visited,
   }
 }
 
-std::vector<QubitSubset> subsets(const QubitSubset&     input,
-                                 const std::size_t      size,
+std::vector<QubitSubset> subsets(const QubitSubset& input,
+                                 const std::size_t size,
                                  const filter_function& filter) {
-  const std::size_t        n = input.size();
+  const std::size_t n = input.size();
   std::vector<QubitSubset> result{};
 
   if (size == 0) {
@@ -242,7 +242,7 @@ std::vector<QubitSubset> subsets(const QubitSubset&     input,
     while ((i >> n) == 0U) {
       assert(i != 0U);
       std::set<std::uint16_t> v{};
-      auto                    it = input.begin();
+      auto it = input.begin();
 
       for (std::size_t j = 0U; j < n; j++, ++it) {
         if ((i & (1U << j)) != 0U) {
@@ -265,12 +265,12 @@ std::vector<QubitSubset> subsets(const QubitSubset&     input,
 }
 
 void parseLine(const std::string& line, char separator,
-               const std::set<char>&     escapeChars,
-               const std::set<char>&     ignoredChars,
+               const std::set<char>& escapeChars,
+               const std::set<char>& ignoredChars,
                std::vector<std::string>& result) {
   result.clear();
   std::string word;
-  bool        inEscape = false;
+  bool inEscape = false;
   for (const char c : line) {
     if (ignoredChars.find(c) != ignoredChars.end()) {
       continue;

--- a/test/cliffordsynthesis/test_synthesis.cpp
+++ b/test/cliffordsynthesis/test_synthesis.cpp
@@ -52,7 +52,7 @@ inline void from_json(const nlohmann::json& j, TestConfiguration& test) {
 
 namespace {
 std::vector<TestConfiguration> getTests(const std::string& path) {
-  std::ifstream  input(path);
+  std::ifstream input(path);
   nlohmann::json j;
   input >> j;
   return j;
@@ -65,7 +65,7 @@ protected:
     test = GetParam();
 
     if (!test.initialCircuit.empty()) {
-      std::stringstream      ss(test.initialCircuit);
+      std::stringstream ss(test.initialCircuit);
       qc::QuantumComputation qc{};
       qc.import(ss, qc::Format::OpenQASM3);
       std::cout << "Initial circuit:\n" << qc;
@@ -73,10 +73,10 @@ protected:
       targetTableauWithDestabilizer =
           Tableau(qc, 0, std::numeric_limits<std::size_t>::max(), true);
       if (test.initialTableau.empty()) {
-        initialTableau                 = Tableau(qc.getNqubits());
+        initialTableau = Tableau(qc.getNqubits());
         initialTableauWithDestabilizer = Tableau(qc.getNqubits(), true);
-        synthesizer                    = CliffordSynthesizer(qc);
-        synthesizerWithDestabilizer    = CliffordSynthesizer(qc, true);
+        synthesizer = CliffordSynthesizer(qc);
+        synthesizerWithDestabilizer = CliffordSynthesizer(qc, true);
       } else {
         initialTableau = Tableau(test.initialTableau);
         std::cout << "Initial tableau:\n" << initialTableau;
@@ -86,7 +86,7 @@ protected:
       targetTableau = Tableau(test.targetTableau);
       if (test.initialTableau.empty()) {
         initialTableau = Tableau(targetTableau.getQubitCount());
-        synthesizer    = CliffordSynthesizer(targetTableau);
+        synthesizer = CliffordSynthesizer(targetTableau);
       } else {
         initialTableau = Tableau(test.initialTableau);
         std::cout << "Initial tableau:\n" << initialTableau;
@@ -95,10 +95,10 @@ protected:
     }
     std::cout << "Target tableau:\n" << targetTableau;
 
-    config                         = Configuration();
-    config.verbosity               = plog::Severity::verbose;
+    config = Configuration();
+    config.verbosity = plog::Severity::verbose;
     config.dumpIntermediateResults = true;
-    config.useSymmetryBreaking     = true;
+    config.useSymmetryBreaking = true;
   }
 
   void TearDown() override {
@@ -121,18 +121,18 @@ protected:
     EXPECT_EQ(resultTableau, circuitTableau);
   }
 
-  Tableau             initialTableau;
-  Tableau             initialTableauWithDestabilizer;
-  Tableau             targetTableau;
-  Tableau             targetTableauWithDestabilizer;
-  Configuration       config;
+  Tableau initialTableau;
+  Tableau initialTableauWithDestabilizer;
+  Tableau targetTableau;
+  Tableau targetTableauWithDestabilizer;
+  Configuration config;
   CliffordSynthesizer synthesizer;
   CliffordSynthesizer synthesizerWithDestabilizer;
-  Results             results;
-  Results             resultsWithDestabilizer;
-  Tableau             resultTableau;
-  Tableau             resultTableauWithDestabilizer;
-  TestConfiguration   test;
+  Results results;
+  Results resultsWithDestabilizer;
+  Tableau resultTableau;
+  Tableau resultTableauWithDestabilizer;
+  TestConfiguration test;
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -158,7 +158,7 @@ TEST_P(SynthesisTest, Gates) {
 }
 
 TEST_P(SynthesisTest, GatesMaxSAT) {
-  config.target    = TargetMetric::Gates;
+  config.target = TargetMetric::Gates;
   config.useMaxSAT = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -167,7 +167,7 @@ TEST_P(SynthesisTest, GatesMaxSAT) {
 }
 
 TEST_P(SynthesisTest, GatesLinearSearch) {
-  config.target       = TargetMetric::Gates;
+  config.target = TargetMetric::Gates;
   config.linearSearch = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -184,7 +184,7 @@ TEST_P(SynthesisTest, Depth) {
 }
 
 TEST_P(SynthesisTest, DepthMaxSAT) {
-  config.target    = TargetMetric::Depth;
+  config.target = TargetMetric::Depth;
   config.useMaxSAT = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -193,7 +193,7 @@ TEST_P(SynthesisTest, DepthMaxSAT) {
 }
 
 TEST_P(SynthesisTest, DepthLinearSearch) {
-  config.target       = TargetMetric::Depth;
+  config.target = TargetMetric::Depth;
   config.linearSearch = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -202,7 +202,7 @@ TEST_P(SynthesisTest, DepthLinearSearch) {
 }
 
 TEST_P(SynthesisTest, DepthMinimalGates) {
-  config.target                              = TargetMetric::Depth;
+  config.target = TargetMetric::Depth;
   config.minimizeGatesAfterDepthOptimization = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -212,7 +212,7 @@ TEST_P(SynthesisTest, DepthMinimalGates) {
 }
 
 TEST_P(SynthesisTest, DepthMinimalTimeSteps) {
-  config.target           = TargetMetric::Depth;
+  config.target = TargetMetric::Depth;
   config.minimalTimesteps = test.expectedMinimalDepth;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -221,8 +221,8 @@ TEST_P(SynthesisTest, DepthMinimalTimeSteps) {
 }
 
 TEST_P(SynthesisTest, DepthMinimalGatesMaxSAT) {
-  config.target                              = TargetMetric::Depth;
-  config.useMaxSAT                           = true;
+  config.target = TargetMetric::Depth;
+  config.useMaxSAT = true;
   config.minimizeGatesAfterDepthOptimization = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -232,8 +232,8 @@ TEST_P(SynthesisTest, DepthMinimalGatesMaxSAT) {
 }
 
 TEST_P(SynthesisTest, DepthMinimalGatesLinearSearch) {
-  config.target                              = TargetMetric::Depth;
-  config.linearSearch                        = true;
+  config.target = TargetMetric::Depth;
+  config.linearSearch = true;
   config.minimizeGatesAfterDepthOptimization = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
@@ -254,7 +254,7 @@ TEST_P(SynthesisTest, TwoQubitGates) {
 TEST_P(SynthesisTest, TwoQubitGatesMaxSAT) {
   config.target = TargetMetric::TwoQubitGates;
   config.tryHigherGateLimitForTwoQubitGateOptimization = true;
-  config.useMaxSAT                                     = true;
+  config.useMaxSAT = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
 
@@ -264,7 +264,7 @@ TEST_P(SynthesisTest, TwoQubitGatesMaxSAT) {
 TEST_P(SynthesisTest, TwoQubitGatesMinimalGates) {
   config.target = TargetMetric::TwoQubitGates;
   config.tryHigherGateLimitForTwoQubitGateOptimization = true;
-  config.minimizeGatesAfterTwoQubitGateOptimization    = true;
+  config.minimizeGatesAfterTwoQubitGateOptimization = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
 
@@ -276,8 +276,8 @@ TEST_P(SynthesisTest, TwoQubitGatesMinimalGates) {
 TEST_P(SynthesisTest, TwoQubitGatesMinimalGatesMaxSAT) {
   config.target = TargetMetric::TwoQubitGates;
   config.tryHigherGateLimitForTwoQubitGateOptimization = true;
-  config.minimizeGatesAfterTwoQubitGateOptimization    = true;
-  config.useMaxSAT                                     = true;
+  config.minimizeGatesAfterTwoQubitGateOptimization = true;
+  config.useMaxSAT = true;
   synthesizer.synthesize(config);
   results = synthesizer.getResults();
 
@@ -289,18 +289,18 @@ TEST_P(SynthesisTest, TwoQubitGatesMinimalGatesMaxSAT) {
 TEST_P(SynthesisTest, TestDestabilizerGates) {
   if (!initialTableauWithDestabilizer.getTableau().empty()) {
     std::cout << "Testing with destabilizer" << std::endl;
-    config.target    = TargetMetric::Gates;
+    config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
     synthesizer.synthesize(config);
     synthesizerWithDestabilizer.synthesize(config);
-    results                 = synthesizer.getResults();
+    results = synthesizer.getResults();
     resultsWithDestabilizer = synthesizerWithDestabilizer.getResults();
 
     EXPECT_GE(resultsWithDestabilizer.getGates(), results.getGates());
   } else {
     std::cout << "Testing without destabilizer" << std::endl;
-    config.target    = TargetMetric::Gates;
+    config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
     synthesizer.synthesize(config);
@@ -311,18 +311,18 @@ TEST_P(SynthesisTest, TestDestabilizerGates) {
 TEST_P(SynthesisTest, TestDestabilizerDepth) {
   if (!initialTableauWithDestabilizer.getTableau().empty()) {
     std::cout << "Testing with destabilizer" << std::endl;
-    config.target    = TargetMetric::Depth;
+    config.target = TargetMetric::Depth;
     config.useMaxSAT = true;
 
     synthesizer.synthesize(config);
     synthesizerWithDestabilizer.synthesize(config);
-    results                 = synthesizer.getResults();
+    results = synthesizer.getResults();
     resultsWithDestabilizer = synthesizerWithDestabilizer.getResults();
 
     EXPECT_GE(resultsWithDestabilizer.getDepth(), results.getDepth());
   } else {
     std::cout << "Testing without destabilizer" << std::endl;
-    config.target    = TargetMetric::Gates;
+    config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
     synthesizer.synthesize(config);
@@ -333,19 +333,19 @@ TEST_P(SynthesisTest, TestDestabilizerDepth) {
 TEST_P(SynthesisTest, TestDestabilizerTwoQubitGates) {
   if (!initialTableauWithDestabilizer.getTableau().empty()) {
     std::cout << "Testing with destabilizer" << std::endl;
-    config.target    = TargetMetric::TwoQubitGates;
+    config.target = TargetMetric::TwoQubitGates;
     config.useMaxSAT = true;
 
     synthesizer.synthesize(config);
     synthesizerWithDestabilizer.synthesize(config);
-    results                 = synthesizer.getResults();
+    results = synthesizer.getResults();
     resultsWithDestabilizer = synthesizerWithDestabilizer.getResults();
 
     EXPECT_GE(resultsWithDestabilizer.getTwoQubitGates(),
               results.getTwoQubitGates());
   } else {
     std::cout << "Testing without destabilizer" << std::endl;
-    config.target    = TargetMetric::Gates;
+    config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
     synthesizer.synthesize(config);
@@ -355,37 +355,37 @@ TEST_P(SynthesisTest, TestDestabilizerTwoQubitGates) {
 
 TEST(HeuristicTest, basic) {
   auto config = Configuration();
-  auto qc     = qc::QuantumComputation(2);
+  auto qc = qc::QuantumComputation(2);
   qc.h(0);
   qc.s(1);
   qc.h(0);
   qc.s(1);
   config.heuristic = true;
   config.splitSize = 1;
-  config.target    = TargetMetric::Depth;
-  auto synth       = CliffordSynthesizer(qc);
+  config.target = TargetMetric::Depth;
+  auto synth = CliffordSynthesizer(qc);
   synth.synthesize(config);
   EXPECT_EQ(synth.getResults().getDepth(), 2);
 }
 
 TEST(HeuristicTest, identity) {
   auto config = Configuration();
-  auto qc     = qc::QuantumComputation(2);
+  auto qc = qc::QuantumComputation(2);
   qc.h(0);
   qc.s(1);
   qc.h(0);
   qc.sdg(1);
   config.heuristic = true;
   config.splitSize = 2;
-  config.target    = TargetMetric::Depth;
-  auto synth       = CliffordSynthesizer(qc);
+  config.target = TargetMetric::Depth;
+  auto synth = CliffordSynthesizer(qc);
   synth.synthesize(config);
   EXPECT_EQ(synth.getResults().getDepth(), 0);
 }
 
 TEST(HeuristicTest, threeLayers) {
   auto config = Configuration();
-  auto qc     = qc::QuantumComputation(2);
+  auto qc = qc::QuantumComputation(2);
   qc.h(0);
   qc.h(1);
   qc.cx(0_pc, 1);
@@ -393,23 +393,23 @@ TEST(HeuristicTest, threeLayers) {
   qc.h(1);
   config.heuristic = true;
   config.splitSize = 2;
-  config.target    = TargetMetric::Depth;
-  auto synth       = CliffordSynthesizer(qc);
+  config.target = TargetMetric::Depth;
+  auto synth = CliffordSynthesizer(qc);
   synth.synthesize(config);
   EXPECT_EQ(synth.getResults().getDepth(), 3);
 }
 
 TEST(HeuristicTest, fourLayers) {
   auto config = Configuration();
-  auto qc     = qc::QuantumComputation(1);
+  auto qc = qc::QuantumComputation(1);
   qc.s(0);
   qc.s(0);
   qc.s(0);
   qc.s(0);
   config.heuristic = true;
   config.splitSize = 2;
-  config.target    = TargetMetric::Depth;
-  auto synth       = CliffordSynthesizer(qc);
+  config.target = TargetMetric::Depth;
+  auto synth = CliffordSynthesizer(qc);
   synth.synthesize(config);
   EXPECT_EQ(synth.getResults().getDepth(), 2);
 }

--- a/test/cliffordsynthesis/test_synthesis.cpp
+++ b/test/cliffordsynthesis/test_synthesis.cpp
@@ -3,9 +3,22 @@
 // See README.md or go to https://github.com/cda-tum/qmap for more information.
 //
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
 #include "cliffordsynthesis/CliffordSynthesizer.hpp"
+#include "cliffordsynthesis/Results.hpp"
+#include "cliffordsynthesis/TargetMetric.hpp"
+#include "operations/Control.hpp"
 
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <plog/Severity.h>
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace qc::literals;
 
@@ -288,7 +301,7 @@ TEST_P(SynthesisTest, TwoQubitGatesMinimalGatesMaxSAT) {
 
 TEST_P(SynthesisTest, TestDestabilizerGates) {
   if (!initialTableauWithDestabilizer.getTableau().empty()) {
-    std::cout << "Testing with destabilizer" << std::endl;
+    std::cout << "Testing with destabilizer\n";
     config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
@@ -299,7 +312,7 @@ TEST_P(SynthesisTest, TestDestabilizerGates) {
 
     EXPECT_GE(resultsWithDestabilizer.getGates(), results.getGates());
   } else {
-    std::cout << "Testing without destabilizer" << std::endl;
+    std::cout << "Testing without destabilizer\n";
     config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
@@ -310,7 +323,7 @@ TEST_P(SynthesisTest, TestDestabilizerGates) {
 
 TEST_P(SynthesisTest, TestDestabilizerDepth) {
   if (!initialTableauWithDestabilizer.getTableau().empty()) {
-    std::cout << "Testing with destabilizer" << std::endl;
+    std::cout << "Testing with destabilizer\n";
     config.target = TargetMetric::Depth;
     config.useMaxSAT = true;
 
@@ -321,7 +334,7 @@ TEST_P(SynthesisTest, TestDestabilizerDepth) {
 
     EXPECT_GE(resultsWithDestabilizer.getDepth(), results.getDepth());
   } else {
-    std::cout << "Testing without destabilizer" << std::endl;
+    std::cout << "Testing without destabilizer\n";
     config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 
@@ -332,7 +345,7 @@ TEST_P(SynthesisTest, TestDestabilizerDepth) {
 
 TEST_P(SynthesisTest, TestDestabilizerTwoQubitGates) {
   if (!initialTableauWithDestabilizer.getTableau().empty()) {
-    std::cout << "Testing with destabilizer" << std::endl;
+    std::cout << "Testing with destabilizer\n";
     config.target = TargetMetric::TwoQubitGates;
     config.useMaxSAT = true;
 
@@ -344,7 +357,7 @@ TEST_P(SynthesisTest, TestDestabilizerTwoQubitGates) {
     EXPECT_GE(resultsWithDestabilizer.getTwoQubitGates(),
               results.getTwoQubitGates());
   } else {
-    std::cout << "Testing without destabilizer" << std::endl;
+    std::cout << "Testing without destabilizer\n";
     config.target = TargetMetric::Gates;
     config.useMaxSAT = true;
 

--- a/test/hybridmap/test_hybridmap.cpp
+++ b/test/hybridmap/test_hybridmap.cpp
@@ -57,25 +57,25 @@ class NeutralAtomMapperTest
           std::tuple<std::string, std::string, qc::fp, qc::fp, qc::fp,
                      na::InitialCoordinateMapping>> {
 protected:
-  std::string                  testArchitecturePath = "architectures/";
-  std::string                  testQcPath           = "circuits/";
-  qc::fp                       gateWeight           = 1;
-  qc::fp                       shuttlingWeight      = 1;
-  qc::fp                       lookAheadWeight      = 1;
+  std::string testArchitecturePath = "architectures/";
+  std::string testQcPath = "circuits/";
+  qc::fp gateWeight = 1;
+  qc::fp shuttlingWeight = 1;
+  qc::fp lookAheadWeight = 1;
   na::InitialCoordinateMapping initialCoordinateMapping =
       na::InitialCoordinateMapping::Trivial;
   // fixed
-  qc::fp   decay               = 0.1;
-  qc::fp   shuttlingTimeWeight = 0.1;
-  uint32_t seed                = 42;
+  qc::fp decay = 0.1;
+  qc::fp shuttlingTimeWeight = 0.1;
+  uint32_t seed = 42;
 
   void SetUp() override {
     auto params = GetParam();
     testArchitecturePath += std::get<0>(params) + ".json";
     testQcPath += std::get<1>(params) + ".qasm";
-    gateWeight               = std::get<2>(params);
-    shuttlingWeight          = std::get<3>(params);
-    lookAheadWeight          = std::get<4>(params);
+    gateWeight = std::get<2>(params);
+    shuttlingWeight = std::get<3>(params);
+    lookAheadWeight = std::get<4>(params);
     initialCoordinateMapping = std::get<5>(params);
   }
 };
@@ -83,22 +83,22 @@ protected:
 TEST_P(NeutralAtomMapperTest, MapCircuitsIdentity) {
   auto arch = na::NeutralAtomArchitecture(testArchitecturePath);
   na::InitialMapping const initialMapping = na::InitialMapping::Identity;
-  na::NeutralAtomMapper    mapper(arch);
-  na::MapperParameters     mapperParameters;
-  mapperParameters.initialMapping       = initialCoordinateMapping;
+  na::NeutralAtomMapper mapper(arch);
+  na::MapperParameters mapperParameters;
+  mapperParameters.initialMapping = initialCoordinateMapping;
   mapperParameters.lookaheadWeightSwaps = lookAheadWeight;
   mapperParameters.lookaheadWeightMoves = lookAheadWeight;
-  mapperParameters.decay                = decay;
-  mapperParameters.shuttlingTimeWeight  = shuttlingTimeWeight;
-  mapperParameters.gateWeight           = gateWeight;
-  mapperParameters.shuttlingWeight      = shuttlingWeight;
-  mapperParameters.seed                 = seed;
-  mapperParameters.verbose              = true;
+  mapperParameters.decay = decay;
+  mapperParameters.shuttlingTimeWeight = shuttlingTimeWeight;
+  mapperParameters.gateWeight = gateWeight;
+  mapperParameters.shuttlingWeight = shuttlingWeight;
+  mapperParameters.seed = seed;
+  mapperParameters.verbose = true;
   mapper.setParameters(mapperParameters);
 
   qc::QuantumComputation qc(testQcPath);
-  auto                   qcMapped    = mapper.map(qc, initialMapping);
-  auto                   qcAodMapped = mapper.convertToAod(qcMapped);
+  auto qcMapped = mapper.map(qc, initialMapping);
+  auto qcAodMapped = mapper.convertToAod(qcMapped);
 
   auto scheduleResults = mapper.schedule(true, true);
 
@@ -124,17 +124,17 @@ TEST(NeutralAtomMapperTest, Output) {
   auto arch =
       na::NeutralAtomArchitecture("architectures/rubidium_shuttling.json");
   na::InitialMapping const initialMapping = na::InitialMapping::Identity;
-  na::NeutralAtomMapper    mapper(arch);
-  na::MapperParameters     mapperParameters;
-  mapperParameters.initialMapping       = na::InitialCoordinateMapping::Trivial;
+  na::NeutralAtomMapper mapper(arch);
+  na::MapperParameters mapperParameters;
+  mapperParameters.initialMapping = na::InitialCoordinateMapping::Trivial;
   mapperParameters.lookaheadWeightSwaps = 0.1;
   mapperParameters.lookaheadWeightMoves = 0.1;
-  mapperParameters.decay                = 0;
-  mapperParameters.shuttlingTimeWeight  = 0.1;
-  mapperParameters.gateWeight           = 1;
-  mapperParameters.shuttlingWeight      = 0;
-  mapperParameters.seed                 = 43;
-  mapperParameters.verbose              = true;
+  mapperParameters.decay = 0;
+  mapperParameters.shuttlingTimeWeight = 0.1;
+  mapperParameters.gateWeight = 1;
+  mapperParameters.shuttlingWeight = 0;
+  mapperParameters.seed = 43;
+  mapperParameters.verbose = true;
   mapper.setParameters(mapperParameters);
 
   qc::QuantumComputation qc(

--- a/test/na/test_architecture.cpp
+++ b/test/na/test_architecture.cpp
@@ -20,7 +20,7 @@
 class NAArchitecture : public testing::Test {
 protected:
   na::Architecture arch;
-  void             SetUp() override {
+  void SetUp() override {
     // write content to a file
     std::istringstream archIS(R"({
       "name": "Nature",
@@ -125,7 +125,7 @@ protected:
           }
       ]
   })");
-    std::stringstream  gridSS;
+    std::stringstream gridSS;
     gridSS << "x,y\n";
     // entangling zone (4 x 36 = 144 sites)
     for (std::size_t y = 0; y <= 36; y += 12) {
@@ -201,7 +201,7 @@ TEST_F(NAArchitecture, GateProperty) {
 
 TEST_F(NAArchitecture, WithConfiguration) {
   na::Configuration const config(2, 3);
-  const auto              modArch = arch.withConfig(config);
+  const auto modArch = arch.withConfig(config);
   EXPECT_EQ(modArch.getNSites(), 216);
 }
 

--- a/test/na/test_configuration.cpp
+++ b/test/na/test_configuration.cpp
@@ -21,7 +21,7 @@ TEST(Configuration, MethodOfString) {
 
 TEST(Configuration, Import) {
   EXPECT_THROW(na::Configuration("nonexistent.json"), std::runtime_error);
-  std::istringstream      configIS(R"(
+  std::istringstream configIS(R"(
     {
       "patch": {
         "rows": 2,

--- a/test/na/test_configuration.cpp
+++ b/test/na/test_configuration.cpp
@@ -3,10 +3,12 @@
 // See README.md or go to https://github.com/cda-tum/qmap for more information.
 //
 
-#include "../../include/configuration/Configuration.hpp"
 #include "Configuration.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <stdexcept>
+#include <tuple>
 
 TEST(Configuration, MethodOfString) {
   EXPECT_EQ(na::getMethodOfString("naive"), na::NAMappingMethod::Naive);

--- a/test/na/test_nagraphalgorithms.cpp
+++ b/test/na/test_nagraphalgorithms.cpp
@@ -22,9 +22,9 @@
 class TestNAGraph : public testing::Test {
 protected:
   qc::QuantumComputation qc;
-  qc::Layer              layer;
-  na::InteractionGraph   graph{};
-  void                   SetUp() override {
+  qc::Layer layer;
+  na::InteractionGraph graph{};
+  void SetUp() override {
     qc = qc::QuantumComputation(8);
     qc.cz(1, 2);
     qc.cz(1, 6);
@@ -191,7 +191,7 @@ TEST_F(TestNAGraph, SequenceOrdering) {
 TEST_F(TestNAGraph, InteractionExists) {
   const auto& sequence = na::NAGraphAlgorithms::computeSequence(graph, 20);
   const auto& moveable = sequence.first;
-  const auto& fixed    = sequence.second;
+  const auto& fixed = sequence.second;
   // check that all interactions are part of the interaction graph
   for (const auto& seq : moveable) {
     for (const auto& s : seq) {
@@ -215,13 +215,13 @@ TEST_F(TestNAGraph, CoveredInteractions) {
   std::vector coveredEdgesVec(coveredEdges.cbegin(), coveredEdges.cend());
   const auto& sequence = na::NAGraphAlgorithms::computeSequence(graph, 20);
   const auto& moveable = sequence.first;
-  const auto& fixed    = sequence.second;
+  const auto& fixed = sequence.second;
   // check that all interactions that are covered by the independent set are
   // part of the sequence
   for (const auto& seq : moveable) {
     for (const auto& s : seq) {
-      const auto  p = s.first;
-      const auto  x = s.second;
+      const auto p = s.first;
+      const auto x = s.second;
       const auto& qIt =
           std::find_if(fixed.cbegin(), fixed.cend(),
                        [&](const auto& q) { return q.second == x; });

--- a/test/na/test_namapper.cpp
+++ b/test/na/test_namapper.cpp
@@ -106,10 +106,10 @@ auto validateAODConstraints(const NAComputation& comp) -> bool {
 }
 
 auto retrieveQuantumComputation(const NAComputation& nac,
-                                const Architecture&  arch)
+                                const Architecture& arch)
     -> qc::QuantumComputation {
-  qc::QuantumComputation               qComp(nac.getInitialPositions().size());
-  std::vector<Point>                   positionOfQubits;
+  qc::QuantumComputation qComp(nac.getInitialPositions().size());
+  std::vector<Point> positionOfQubits;
   std::unordered_map<Point, qc::Qubit> positionToQubit;
   positionOfQubits.reserve(nac.getInitialPositions().size());
   qc::Qubit n = 0;
@@ -180,15 +180,15 @@ auto retrieveQuantumComputation(const NAComputation& nac,
 }
 
 auto checkEquivalence(const qc::QuantumComputation& circ,
-                      const NAComputation&          nac,
-                      const Architecture&           arch) -> bool {
-  auto            naQComp = retrieveQuantumComputation(nac, arch);
+                      const NAComputation& nac,
+                      const Architecture& arch) -> bool {
+  auto naQComp = retrieveQuantumComputation(nac, arch);
   const qc::Layer qLayer(circ);
-  int             line = 0;
+  int line = 0;
   for (const auto& op : naQComp) {
     ++line;
     const auto& executableSet = qLayer.getExecutableSet();
-    const auto& it            = std::find_if(
+    const auto& it = std::find_if(
         executableSet.begin(), executableSet.end(),
         [&op](const std::shared_ptr<qc::Layer::DAGVertex>& vertex) {
           return *vertex->getOperation() == *op;
@@ -314,7 +314,7 @@ TEST(NAMapper, Exceptions) {
           }
       ]
   })");
-  std::stringstream  gridSS;
+  std::stringstream gridSS;
   gridSS << "x,y\n";
   // entangling zone (4 x 36 = 144 sites)
   for (std::size_t y = 0; y <= 36; y += 12) {
@@ -468,7 +468,7 @@ TEST(NAMapper, QAOA10) {
           }
       ]
   })");
-  std::stringstream  gridSS;
+  std::stringstream gridSS;
   gridSS << "x,y\n";
   // entangling zone (4 x 36 = 144 sites)
   for (std::size_t y = 0; y <= 36; y += 12) {
@@ -749,8 +749,8 @@ rz(3.9927041) q[3];
 rz(3.9927041) q[4];
 rz(3.9927041) q[5];
 rz(3.9927041) q[7];)";
-  const auto&       circ = qc::QuantumComputation::fromQASM(qasm);
-  const auto&       arch = na::Architecture(archIS, gridSS);
+  const auto& circ = qc::QuantumComputation::fromQASM(qasm);
+  const auto& arch = na::Architecture(archIS, gridSS);
   // ---------------------------------------------------------------------
   na::NAMapper mapper(
       arch, na::Configuration(
@@ -882,7 +882,7 @@ TEST(NAMapper, QAOA16Narrow) {
       ]
   }
   )");
-  std::stringstream  gridSS;
+  std::stringstream gridSS;
   gridSS << "x,y\n";
   // entangling zone (4 x 36 = 144 sites)
   for (std::size_t y = 0; y <= 36; y += 12) {
@@ -1002,8 +1002,8 @@ ry(0.3223291) q;
 cp(pi) q[9],q[11];
 ry(-2.2154814) q;
 ry(2.2154814) q;)";
-  const auto&       circ = qc::QuantumComputation::fromQASM(qasm);
-  const auto&       arch = na::Architecture(archIS, gridSS);
+  const auto& circ = qc::QuantumComputation::fromQASM(qasm);
+  const auto& arch = na::Architecture(archIS, gridSS);
   // ---------------------------------------------------------------------
   na::NAMapper mapper(
       arch, na::Configuration(
@@ -1118,7 +1118,7 @@ TEST(NAMapper, QAOA16NarrowEntangling) {
       ]
   }
   )");
-  std::stringstream  gridSS;
+  std::stringstream gridSS;
   gridSS << "x,y\n";
   // entangling zone (4 x 36 = 144 sites)
   for (std::size_t y = 0; y <= 36; y += 12) {
@@ -1238,8 +1238,8 @@ ry(0.3223291) q;
 cp(pi) q[9],q[11];
 ry(-2.2154814) q;
 ry(2.2154814) q;)";
-  const auto&       circ = qc::QuantumComputation::fromQASM(qasm);
-  const auto&       arch = na::Architecture(archIS, gridSS);
+  const auto& circ = qc::QuantumComputation::fromQASM(qasm);
+  const auto& arch = na::Architecture(archIS, gridSS);
   // ---------------------------------------------------------------------
   na::NAMapper mapper(
       arch, na::Configuration(

--- a/test/test_architecture.cpp
+++ b/test/test_architecture.cpp
@@ -4,9 +4,21 @@
 //
 
 #include "Architecture.hpp"
+#include "operations/OpType.hpp"
+#include "utils.hpp"
 
-#include "gtest/gtest.h"
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <iostream>
 #include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 ::testing::AssertionResult matrixNear(const Matrix& a, const Matrix& b,
                                       double delta) {

--- a/test/test_architecture.cpp
+++ b/test/test_architecture.cpp
@@ -35,7 +35,7 @@
 class TestArchitecture : public testing::TestWithParam<std::string> {
 protected:
   std::string testArchitectureDir = "../extern/architectures/";
-  std::string testCalibrationDir  = "../extern/calibration/";
+  std::string testCalibrationDir = "../extern/calibration/";
 };
 
 INSTANTIATE_TEST_SUITE_P(Architecture, TestArchitecture,
@@ -44,8 +44,8 @@ INSTANTIATE_TEST_SUITE_P(Architecture, TestArchitecture,
                                          "ibmq_london.csv"));
 
 TEST_P(TestArchitecture, QubitMap) {
-  const auto&       archName = GetParam();
-  Architecture      arch{};
+  const auto& archName = GetParam();
+  Architecture arch{};
   std::stringstream ss{};
   if (archName.find(".arch") != std::string::npos) {
     ss << testArchitectureDir << archName;
@@ -59,8 +59,8 @@ TEST_P(TestArchitecture, QubitMap) {
             arch.getNqubits());
 }
 TEST_P(TestArchitecture, GetAllConnectedSubsets) {
-  const auto&       archName = GetParam();
-  Architecture      arch{};
+  const auto& archName = GetParam();
+  Architecture arch{};
   std::stringstream ss{};
   if (archName.find(".arch") != std::string::npos) {
     ss << testArchitectureDir << archName;
@@ -74,8 +74,8 @@ TEST_P(TestArchitecture, GetAllConnectedSubsets) {
   EXPECT_EQ(arch.getAllConnectedSubsets(1).size(), arch.getNqubits());
 }
 TEST_P(TestArchitecture, GetHighestFidelity) {
-  const auto&       archName = GetParam();
-  Architecture      arch{};
+  const auto& archName = GetParam();
+  Architecture arch{};
   std::stringstream ss{};
   if (archName.find(".arch") != std::string::npos) {
     ss << testArchitectureDir << archName;
@@ -93,8 +93,8 @@ TEST_P(TestArchitecture, GetHighestFidelity) {
   EXPECT_TRUE(cm.empty());
 }
 TEST_P(TestArchitecture, ReducedMaps) {
-  const auto&       archName = GetParam();
-  Architecture      arch{};
+  const auto& archName = GetParam();
+  Architecture arch{};
   std::stringstream ss{};
   if (archName.find(".arch") != std::string::npos) {
     ss << testArchitectureDir << archName;
@@ -113,7 +113,7 @@ TEST_P(TestArchitecture, ReducedMaps) {
 
 TEST(TestArchitecture, ConnectedTest) {
   Architecture architecture{};
-  CouplingMap  cm{};
+  CouplingMap cm{};
 
   cm.emplace(std::make_pair(0, 1));
   cm.emplace(std::make_pair(1, 2));
@@ -138,7 +138,7 @@ TEST(TestArchitecture, ConnectedTest) {
 
 TEST(TestArchitecture, FidelityTest) {
   Architecture architecture{};
-  CouplingMap  cm{};
+  CouplingMap cm{};
 
   auto props = Architecture::Properties();
   props.setNqubits(4);
@@ -158,7 +158,7 @@ TEST(TestArchitecture, FidelityTest) {
   architecture.getHighestFidelityCouplingMap(2, cm);
 
   const std::vector<std::uint16_t> highestFidelity{2, 3};
-  auto                             qubitList = Architecture::getQubitList(cm);
+  auto qubitList = Architecture::getQubitList(cm);
 
   EXPECT_EQ(qubitList, highestFidelity);
 }
@@ -170,7 +170,7 @@ TEST(TestArchitecture, FullyConnectedTest) {
 }
 
 TEST(TestArchitecture, MinimumNumberOfSwapsError) {
-  Architecture               architecture{};
+  Architecture architecture{};
   std::vector<std::uint16_t> permutation{1, 1, 2, 3, 4};
   printPi(permutation);
   std::vector<Edge> swaps{};
@@ -179,7 +179,7 @@ TEST(TestArchitecture, MinimumNumberOfSwapsError) {
 }
 
 TEST(TestArchitecture, TestCouplingLimitRing) {
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
                           {3, 2}, {3, 4}, {4, 3}, {4, 0}, {0, 4}};
   architecture.loadCouplingMap(5, cm);
@@ -188,10 +188,10 @@ TEST(TestArchitecture, TestCouplingLimitRing) {
 
 TEST(TestArchitecture, opTypeFromString) {
   Architecture arch{2, {{0, 1}}};
-  auto&        props = arch.getProperties();
+  auto& props = arch.getProperties();
 
-  std::random_device               rd;
-  std::mt19937                     gen(rd());
+  std::random_device rd;
+  std::mt19937 gen(rd());
   std::uniform_real_distribution<> dis(0., 1.);
 
   const std::vector<std::pair<std::string, qc::OpType>> singleQubitGates = {
@@ -269,7 +269,7 @@ TEST(TestArchitecture, FidelityDistanceBidirectionalTest) {
   -[]- ... 2-qubit error rates
   []   ... 1-qubit error rates
   */
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2},
                           {1, 4}, {4, 1}, {2, 5}, {5, 2}, {5, 6}, {6, 5}};
   architecture.loadCouplingMap(7, cm);
@@ -505,7 +505,7 @@ TEST(TestArchitecture, FidelityDistanceSemiBidirectionalTest) {
 =[]= ... 2-qubit error rates of bidirectional edge
 []   ... 1-qubit error rates
 */
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
                           {3, 2}, {1, 4}, {2, 5}, {5, 2}, {6, 5}};
   architecture.loadCouplingMap(7, cm);
@@ -747,7 +747,7 @@ TEST(TestArchitecture, FidelityDistanceSemiBidirectionalTest) {
 }
 
 TEST(TestArchitecture, FidelitySwapCostTest) {
-  const double      tolerance = 1e-6;
+  const double tolerance = 1e-6;
   const CouplingMap cm = {{0, 1}, {1, 2}, {2, 1}, {2, 3}, {2, 4}, {4, 2}};
 
   auto props = Architecture::Properties();
@@ -822,7 +822,7 @@ TEST(TestArchitecture, FidelitySwapCostTest) {
 TEST(TestArchitecture, FidelityDistanceCheapestPathTest) {
   // tests if the distance measure actually finds the cheapest path and
   // not just the shortest
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {2, 1}, {2, 6}, {6, 2},
                           {0, 5}, {5, 0}, {5, 6}, {6, 5}, {0, 3},
                           {3, 0}, {3, 4}, {4, 3}, {4, 6}, {6, 4}};

--- a/test/test_encodings.cpp
+++ b/test/test_encodings.cpp
@@ -10,14 +10,14 @@
 class TestEncodings
     : public testing::TestWithParam<std::pair<Encoding, CommanderGrouping>> {
 protected:
-  qc::QuantumComputation       qc{};
-  Configuration                settings{};
-  Architecture                 arch{};
+  qc::QuantumComputation qc{};
+  Configuration settings{};
+  Architecture arch{};
   std::unique_ptr<ExactMapper> mapper{};
 
   void SetUp() override {
-    settings.verbose    = true;
-    settings.method     = Method::Exact;
+    settings.verbose = true;
+    settings.method = Method::Exact;
     settings.useSubsets = false;
   }
 };
@@ -44,8 +44,8 @@ TEST_P(TestEncodings, ThreeToSevenQubits) {
   mapper = std::make_unique<ExactMapper>(qc, arch);
 
   const auto& [encoding, grouping] = GetParam();
-  settings.encoding                = encoding;
-  settings.commanderGrouping       = grouping;
+  settings.encoding = encoding;
+  settings.commanderGrouping = grouping;
 
   mapper->map(settings);
   mapper->printResult(std::cout);
@@ -68,8 +68,8 @@ TEST_P(TestEncodings, FiveToSevenQubits) {
   mapper = std::make_unique<ExactMapper>(qc, arch);
 
   const auto& [encoding, grouping] = GetParam();
-  settings.encoding                = encoding;
-  settings.commanderGrouping       = grouping;
+  settings.encoding = encoding;
+  settings.commanderGrouping = grouping;
 
   mapper->map(settings);
   mapper->printResult(std::cout);

--- a/test/test_encodings.cpp
+++ b/test/test_encodings.cpp
@@ -3,17 +3,28 @@
 // See README.md or go to https://github.com/cda-tum/qmap for more information.
 //
 
+#include "Architecture.hpp"
+#include "QuantumComputation.hpp"
+#include "configuration/AvailableArchitecture.hpp"
+#include "configuration/CommanderGrouping.hpp"
+#include "configuration/Configuration.hpp"
+#include "configuration/Encoding.hpp"
+#include "configuration/Method.hpp"
 #include "exact/ExactMapper.hpp"
+#include "operations/Control.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <utility>
 
 class TestEncodings
     : public testing::TestWithParam<std::pair<Encoding, CommanderGrouping>> {
 protected:
-  qc::QuantumComputation qc{};
+  qc::QuantumComputation qc;
   Configuration settings{};
-  Architecture arch{};
-  std::unique_ptr<ExactMapper> mapper{};
+  Architecture arch;
+  std::unique_ptr<ExactMapper> mapper;
 
   void SetUp() override {
     settings.verbose = true;

--- a/test/test_exact.cpp
+++ b/test/test_exact.cpp
@@ -30,15 +30,15 @@
 
 class ExactTest : public testing::TestWithParam<std::string> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
-  std::string testCalibrationDir  = "../extern/calibration/";
+  std::string testCalibrationDir = "../extern/calibration/";
 
-  qc::QuantumComputation       qc;
-  Configuration                settings{};
-  Architecture                 ibmqYorktown;
-  Architecture                 ibmqLondon;
-  Architecture                 ibmQX4;
+  qc::QuantumComputation qc;
+  Configuration settings{};
+  Architecture ibmqYorktown;
+  Architecture ibmqLondon;
+  Architecture ibmQX4;
   std::unique_ptr<ExactMapper> ibmqYorktownMapper;
   std::unique_ptr<ExactMapper> ibmqLondonMapper;
   std::unique_ptr<ExactMapper> ibmQX4Mapper;
@@ -62,11 +62,11 @@ protected:
     ibmQX4.loadCouplingMap(AvailableArchitecture::IbmQx4);
 
     ibmqYorktownMapper = std::make_unique<ExactMapper>(qc, ibmqYorktown);
-    ibmqLondonMapper   = std::make_unique<ExactMapper>(qc, ibmqLondon);
-    ibmQX4Mapper       = std::make_unique<ExactMapper>(qc, ibmQX4);
+    ibmqLondonMapper = std::make_unique<ExactMapper>(qc, ibmqLondon);
+    ibmQX4Mapper = std::make_unique<ExactMapper>(qc, ibmQX4);
 
     settings.verbose = true;
-    settings.method  = Method::Exact;
+    settings.method = Method::Exact;
   }
 };
 
@@ -134,7 +134,7 @@ TEST_P(ExactTest, QubitTriangle) {
 }
 
 TEST_P(ExactTest, CommanderEncodingfixed3) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Fixed3;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
@@ -143,7 +143,7 @@ TEST_P(ExactTest, CommanderEncodingfixed3) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingfixed2) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Fixed2;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
@@ -152,7 +152,7 @@ TEST_P(ExactTest, CommanderEncodingfixed2) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodinghalves) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Halves;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
@@ -161,7 +161,7 @@ TEST_P(ExactTest, CommanderEncodinghalves) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodinglogarithm) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Logarithm;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
@@ -171,7 +171,7 @@ TEST_P(ExactTest, CommanderEncodinglogarithm) {
 }
 
 TEST_P(ExactTest, CommanderEncodingUnidirectionalfixed3) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Fixed3;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_commander_fixed3.qasm");
@@ -179,7 +179,7 @@ TEST_P(ExactTest, CommanderEncodingUnidirectionalfixed3) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingUnidirectionalfixed2) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Fixed2;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_commander_fixed2.qasm");
@@ -187,7 +187,7 @@ TEST_P(ExactTest, CommanderEncodingUnidirectionalfixed2) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingUnidirectionalhalves) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Halves;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_commander_halves.qasm");
@@ -195,7 +195,7 @@ TEST_P(ExactTest, CommanderEncodingUnidirectionalhalves) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, CommanderEncodingUnidirectionallogarithm) {
-  settings.encoding          = Encoding::Commander;
+  settings.encoding = Encoding::Commander;
   settings.commanderGrouping = CommanderGrouping::Logarithm;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_commander_log.qasm");
@@ -204,7 +204,7 @@ TEST_P(ExactTest, CommanderEncodingUnidirectionallogarithm) {
 }
 
 TEST_P(ExactTest, BimanderEncodingfixed3) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Fixed3;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
@@ -212,7 +212,7 @@ TEST_P(ExactTest, BimanderEncodingfixed3) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingfixed2) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Fixed2;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
@@ -220,7 +220,7 @@ TEST_P(ExactTest, BimanderEncodingfixed2) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodinghalves) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Halves;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
@@ -228,7 +228,7 @@ TEST_P(ExactTest, BimanderEncodinghalves) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodinglogaritm) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Logarithm;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() + "_exact_yorktown_bimander.qasm");
@@ -237,7 +237,7 @@ TEST_P(ExactTest, BimanderEncodinglogaritm) {
 }
 
 TEST_P(ExactTest, BimanderEncodingUnidirectionalfixed3) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Fixed3;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
@@ -245,7 +245,7 @@ TEST_P(ExactTest, BimanderEncodingUnidirectionalfixed3) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingUnidirectionalfixed2) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Fixed2;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
@@ -253,7 +253,7 @@ TEST_P(ExactTest, BimanderEncodingUnidirectionalfixed2) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingUnidirectionalhalves) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Halves;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
@@ -261,7 +261,7 @@ TEST_P(ExactTest, BimanderEncodingUnidirectionalhalves) {
   SUCCEED() << "Mapping successful";
 }
 TEST_P(ExactTest, BimanderEncodingUnidirectionallogarithm) {
-  settings.encoding          = Encoding::Bimander;
+  settings.encoding = Encoding::Bimander;
   settings.commanderGrouping = CommanderGrouping::Logarithm;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_bimander.qasm");
@@ -271,8 +271,8 @@ TEST_P(ExactTest, BimanderEncodingUnidirectionallogarithm) {
 
 TEST_P(ExactTest, LimitsBidirectional) {
   settings.enableSwapLimits = true;
-  settings.useSubsets       = false;
-  settings.swapReduction    = SwapReduction::CouplingLimit;
+  settings.useSubsets = false;
+  settings.swapReduction = SwapReduction::CouplingLimit;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
                                  "_exact_yorktown_swapreduct.qasm");
@@ -281,8 +281,8 @@ TEST_P(ExactTest, LimitsBidirectional) {
 }
 TEST_P(ExactTest, LimitsBidirectionalSubsetSwaps) {
   settings.enableSwapLimits = true;
-  settings.useSubsets       = true;
-  settings.swapReduction    = SwapReduction::CouplingLimit;
+  settings.useSubsets = true;
+  settings.swapReduction = SwapReduction::CouplingLimit;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
                                  "_exact_yorktown_swapreduct.qasm");
@@ -291,8 +291,8 @@ TEST_P(ExactTest, LimitsBidirectionalSubsetSwaps) {
 }
 TEST_P(ExactTest, LimitsBidirectionalCustomLimit) {
   settings.enableSwapLimits = true;
-  settings.swapReduction    = SwapReduction::Custom;
-  settings.swapLimit        = 10;
+  settings.swapReduction = SwapReduction::Custom;
+  settings.swapLimit = 10;
   ibmqYorktownMapper->map(settings);
   ibmqYorktownMapper->dumpResult(GetParam() +
                                  "_exact_yorktown_swapreduct.qasm");
@@ -302,8 +302,8 @@ TEST_P(ExactTest, LimitsBidirectionalCustomLimit) {
 
 TEST_P(ExactTest, LimitsUnidirectional) {
   settings.enableSwapLimits = true;
-  settings.useSubsets       = false;
-  settings.swapReduction    = SwapReduction::CouplingLimit;
+  settings.useSubsets = false;
+  settings.swapReduction = SwapReduction::CouplingLimit;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
   ibmQX4Mapper->printResult(std::cout);
@@ -311,8 +311,8 @@ TEST_P(ExactTest, LimitsUnidirectional) {
 }
 TEST_P(ExactTest, LimitsUnidirectionalSubsetSwaps) {
   settings.enableSwapLimits = true;
-  settings.useSubsets       = true;
-  settings.swapReduction    = SwapReduction::CouplingLimit;
+  settings.useSubsets = true;
+  settings.swapReduction = SwapReduction::CouplingLimit;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
   ibmQX4Mapper->printResult(std::cout);
@@ -320,8 +320,8 @@ TEST_P(ExactTest, LimitsUnidirectionalSubsetSwaps) {
 }
 TEST_P(ExactTest, LimitsUnidirectionalCustomLimit) {
   settings.enableSwapLimits = true;
-  settings.swapReduction    = SwapReduction::Custom;
-  settings.swapLimit        = 10;
+  settings.swapReduction = SwapReduction::Custom;
+  settings.swapLimit = 10;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct.qasm");
   ibmQX4Mapper->printResult(std::cout);
@@ -329,8 +329,8 @@ TEST_P(ExactTest, LimitsUnidirectionalCustomLimit) {
 }
 TEST_P(ExactTest, IncreasingCustomLimitUnidirectional) {
   settings.enableSwapLimits = true;
-  settings.swapReduction    = SwapReduction::Increasing;
-  settings.swapLimit        = 3;
+  settings.swapReduction = SwapReduction::Increasing;
+  settings.swapLimit = 3;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct_inccustom.qasm");
   ibmQX4Mapper->printResult(std::cout);
@@ -338,8 +338,8 @@ TEST_P(ExactTest, IncreasingCustomLimitUnidirectional) {
 }
 TEST_P(ExactTest, IncreasingUnidirectional) {
   settings.enableSwapLimits = true;
-  settings.swapReduction    = SwapReduction::Increasing;
-  settings.swapLimit        = 0;
+  settings.swapReduction = SwapReduction::Increasing;
+  settings.swapLimit = 0;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_swapreduct_inc.qasm");
   ibmQX4Mapper->printResult(std::cout);
@@ -347,7 +347,7 @@ TEST_P(ExactTest, IncreasingUnidirectional) {
 }
 
 TEST_P(ExactTest, NoSubsets) {
-  settings.useSubsets       = false;
+  settings.useSubsets = false;
   settings.enableSwapLimits = false;
   ibmQX4Mapper->map(settings);
   ibmQX4Mapper->dumpResult(GetParam() + "_exact_QX4_nosubsets.qasm");
@@ -396,15 +396,15 @@ TEST_F(ExactTest, CircuitWithOnlySingleQubitGates) {
 TEST_F(ExactTest, MapToSubsetNotIncludingQ0) {
   const CouplingMap cm{{0, 1}, {1, 0}, {1, 2}, {2, 1},
                        {2, 3}, {3, 2}, {1, 3}, {3, 1}};
-  Architecture      arch(4U, cm);
+  Architecture arch(4U, cm);
 
-  auto mapper         = ExactMapper(qc, arch);
+  auto mapper = ExactMapper(qc, arch);
   settings.useSubsets = false;
   mapper.map(settings);
 
   std::ostringstream oss{};
   mapper.dumpResult(oss, qc::Format::OpenQASM3);
-  auto               qcMapped = qc::QuantumComputation();
+  auto qcMapped = qc::QuantumComputation();
   std::istringstream iss{oss.str()};
   qcMapped.import(iss, qc::Format::OpenQASM3);
   std::cout << qcMapped << '\n';
@@ -415,7 +415,7 @@ TEST_F(ExactTest, MapToSubsetNotIncludingQ0) {
 }
 
 TEST_F(ExactTest, WCNF) {
-  settings.verbose     = false;
+  settings.verbose = false;
   settings.includeWCNF = true;
   ibmqLondonMapper->map(settings);
   ibmqLondonMapper->printResult(std::cout);
@@ -426,8 +426,8 @@ TEST_F(ExactTest, WCNF) {
 TEST_F(ExactTest, WCNFNotAvailable) {
   using namespace qc::literals;
 
-  settings.verbose     = false;
-  settings.encoding    = Encoding::Naive;
+  settings.verbose = false;
+  settings.encoding = Encoding::Naive;
   settings.includeWCNF = true;
 
   auto circ = qc::QuantumComputation(5U);
@@ -442,7 +442,7 @@ TEST_F(ExactTest, WCNFNotAvailable) {
   mapper.map(settings);
   EXPECT_TRUE(mapper.getResults().wcnf.empty());
 
-  auto mapper2      = ExactMapper(circ, ibmqLondon);
+  auto mapper2 = ExactMapper(circ, ibmqLondon);
   settings.encoding = Encoding::Commander;
   mapper2.map(settings);
   EXPECT_FALSE(mapper2.getResults().wcnf.empty());
@@ -498,7 +498,7 @@ TEST_F(ExactTest, NoMeasurementsAdded) {
   ibmqLondonMapper->map(settings);
 
   // get the resulting circuit
-  auto              qcMapped = qc::QuantumComputation();
+  auto qcMapped = qc::QuantumComputation();
   std::stringstream qasm{};
   ibmqLondonMapper->dumpResult(qasm, qc::Format::OpenQASM3);
   qcMapped.import(qasm, qc::Format::OpenQASM3);
@@ -509,7 +509,7 @@ TEST_F(ExactTest, NoMeasurementsAdded) {
 }
 
 TEST_F(ExactTest, Test4QCircuitThatUsesAll5Q) {
-  Architecture      arch;
+  Architecture arch;
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
                           {3, 2}, {3, 4}, {4, 3}, {4, 0}, {0, 4}};
   arch.loadCouplingMap(5, cm);
@@ -535,7 +535,7 @@ TEST_F(ExactTest, RegressionTestDirectionReverseCost) {
   // Regression test for https://github.com/cda-tum/qmap/issues/251
   using namespace qc::literals;
 
-  Architecture      arch;
+  Architecture arch;
   const CouplingMap cm = {{1, 0}, {2, 0}, {2, 1}, {4, 2}, {3, 2}, {3, 4}};
   arch.loadCouplingMap(5, cm);
 
@@ -577,18 +577,18 @@ TEST_F(ExactTest, RegressionTestExactMapperPerformance) {
                        "cx q[1],q[0];\n"
                        "cx q[1],q[2];\n"};
 
-  Architecture      arch;
+  Architecture arch;
   const CouplingMap cm = {{1, 0}, {2, 0}, {2, 1}, {3, 2}, {3, 4}, {4, 2}};
   arch.loadCouplingMap(5, cm);
   qc.import(ss, qc::Format::OpenQASM3);
 
-  auto mapper            = ExactMapper(qc, arch);
+  auto mapper = ExactMapper(qc, arch);
   settings.swapReduction = SwapReduction::CouplingLimit;
   mapper.map(settings);
   EXPECT_EQ(mapper.getResults().output.swaps, 1);
   EXPECT_EQ(mapper.getResults().output.directionReverse, 4);
 
-  auto mapper2           = ExactMapper(qc, arch);
+  auto mapper2 = ExactMapper(qc, arch);
   settings.swapReduction = SwapReduction::None;
   mapper2.map(settings);
   EXPECT_EQ(mapper2.getResults().output.swaps, 1);
@@ -609,18 +609,18 @@ TEST_F(ExactTest, RegressionTestExactMapperPerformance2) {
                        "cx q[0],q[1];\n"
                        "cx q[1],q[2];\n"};
 
-  Architecture      arch;
+  Architecture arch;
   const CouplingMap cm = {{1, 0}, {2, 0}, {2, 1}, {3, 2}, {3, 4}, {4, 2}};
   arch.loadCouplingMap(5, cm);
   qc.import(ss, qc::Format::OpenQASM3);
 
-  auto mapper            = ExactMapper(qc, arch);
+  auto mapper = ExactMapper(qc, arch);
   settings.swapReduction = SwapReduction::CouplingLimit;
   mapper.map(settings);
   EXPECT_EQ(mapper.getResults().output.swaps, 1);
   EXPECT_EQ(mapper.getResults().output.directionReverse, 1);
 
-  auto mapper2           = ExactMapper(qc, arch);
+  auto mapper2 = ExactMapper(qc, arch);
   settings.swapReduction = SwapReduction::None;
   mapper2.map(settings);
   EXPECT_EQ(mapper2.getResults().output.swaps, 1);

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -89,7 +89,7 @@ TEST(General, DijkstraCNOTReversal) {
                               {0, 3, 0, 3, 0},
                               {0, 0, 3, 0, 3},
                               {0, 0, 0, 3, 0}};
-  Matrix       simpleDistanceTable{};
+  Matrix simpleDistanceTable{};
   Dijkstra::buildTable(cm, simpleDistanceTable, edgeWeights);
   Matrix fullDistanceTable{};
   Dijkstra::buildSingleEdgeSkipTable(simpleDistanceTable, cm, 1.,

--- a/test/test_heuristic.cpp
+++ b/test/test_heuristic.cpp
@@ -41,8 +41,8 @@
 #include <utility>
 #include <vector>
 
-constexpr qc::OpType SWAP            = qc::OpType::SWAP;
-constexpr double     FLOAT_TOLERANCE = 1e-6;
+constexpr qc::OpType SWAP = qc::OpType::SWAP;
+constexpr double FLOAT_TOLERANCE = 1e-6;
 
 /**
  * @brief Get id of the final node in a given layer from a data log.
@@ -153,9 +153,9 @@ void parseNodesFromDatalog(std::string dataLoggingPath, std::size_t layer,
     }
     if (std::getline(lineStream, col, ';')) {
       std::stringstream qubitMapBuffer(col);
-      std::string       entry;
+      std::string entry;
       for (std::size_t i = 0; std::getline(qubitMapBuffer, entry, ','); ++i) {
-        auto qubit        = static_cast<std::int16_t>(std::stoi(entry));
+        auto qubit = static_cast<std::int16_t>(std::stoi(entry));
         node.qubits.at(i) = qubit;
         if (qubit >= 0) {
           node.locations.at(static_cast<std::size_t>(qubit)) =
@@ -168,11 +168,11 @@ void parseNodesFromDatalog(std::string dataLoggingPath, std::size_t layer,
     }
     if (std::getline(lineStream, col, ';')) {
       std::stringstream swapBuffer(col);
-      std::string       entry;
+      std::string entry;
       while (std::getline(swapBuffer, entry, ',')) {
         std::uint16_t q1 = 0;
         std::uint16_t q2 = 0;
-        std::string   opTypeStr;
+        std::string opTypeStr;
         std::stringstream(entry) >> q1 >> q2 >> opTypeStr;
         qc::OpType opType = SWAP;
         if (!opTypeStr.empty()) {
@@ -227,9 +227,9 @@ protected:
 Architecture InternalsTest::defaultArch{1, {}};
 
 TEST_F(InternalsTest, NodeCostCalculation) {
-  results.config.heuristic          = Heuristic::GateCountMaxDistance;
+  results.config.heuristic = Heuristic::GateCountMaxDistance;
   results.config.lookaheadHeuristic = LookaheadHeuristic::None;
-  results.config.layering           = Layering::Disjoint2qBlocks;
+  results.config.layering = Layering::Disjoint2qBlocks;
 
   architecture->loadCouplingMap(5, {{0, 1}, {1, 2}, {3, 1}, {4, 3}});
   qc = qc::QuantumComputation{5};
@@ -311,9 +311,9 @@ TEST_F(InternalsTest, NodeCostCalculation) {
 }
 
 TEST_F(InternalsTest, NodeLookaheadCalculation) {
-  results.config.heuristic          = Heuristic::GateCountMaxDistance;
+  results.config.heuristic = Heuristic::GateCountMaxDistance;
   results.config.lookaheadHeuristic = LookaheadHeuristic::None;
-  results.config.layering           = Layering::Disjoint2qBlocks;
+  results.config.layering = Layering::Disjoint2qBlocks;
 
   architecture->loadCouplingMap(5, {{0, 1}, {1, 2}, {3, 1}, {4, 3}});
   qc = qc::QuantumComputation{5};
@@ -359,10 +359,10 @@ TEST_F(InternalsTest, NodeLookaheadCalculation) {
   EXPECT_NEAR(node.lookaheadPenalty, 0., FLOAT_TOLERANCE);
 
   results.config.firstLookaheadFactor = 0.75;
-  results.config.lookaheadFactor      = 0.5;
+  results.config.lookaheadFactor = 0.5;
 
   results.config.lookaheadHeuristic = LookaheadHeuristic::GateCountMaxDistance;
-  results.config.nrLookaheads       = 1;
+  results.config.nrLookaheads = 1;
   updateLookaheadPenalty(0, node);
   EXPECT_NEAR(node.lookaheadPenalty, 0.75 * (2 * COST_UNIDIRECTIONAL_SWAP),
               FLOAT_TOLERANCE);
@@ -388,7 +388,7 @@ TEST_F(InternalsTest, NodeLookaheadCalculation) {
               FLOAT_TOLERANCE);
 
   results.config.lookaheadHeuristic = LookaheadHeuristic::GateCountSumDistance;
-  results.config.nrLookaheads       = 1;
+  results.config.nrLookaheads = 1;
   updateLookaheadPenalty(0, node);
   EXPECT_NEAR(node.lookaheadPenalty,
               0.75 * (3 * COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE),
@@ -414,18 +414,18 @@ TEST_F(InternalsTest, NodeLookaheadCalculation) {
                   0.75 * 0.5 * 0.5 * (2 * COST_UNIDIRECTIONAL_SWAP),
               FLOAT_TOLERANCE);
 
-  node.qubits    = {4, 3, 1, -1, -1};
+  node.qubits = {4, 3, 1, -1, -1};
   node.locations = {-1, 2, -1, 1, 0};
 
   results.config.lookaheadHeuristic = LookaheadHeuristic::GateCountMaxDistance;
-  results.config.nrLookaheads       = 1;
+  results.config.nrLookaheads = 1;
   updateLookaheadPenalty(0, node);
   EXPECT_NEAR(node.lookaheadPenalty,
               0.75 * (COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE),
               FLOAT_TOLERANCE);
 
   results.config.lookaheadHeuristic = LookaheadHeuristic::GateCountSumDistance;
-  results.config.nrLookaheads       = 1;
+  results.config.nrLookaheads = 1;
   updateLookaheadPenalty(0, node);
   EXPECT_NEAR(node.lookaheadPenalty,
               0.75 * (2 * COST_UNIDIRECTIONAL_SWAP + COST_DIRECTION_REVERSE),
@@ -435,19 +435,19 @@ TEST_F(InternalsTest, NodeLookaheadCalculation) {
 class TestHeuristics
     : public testing::TestWithParam<std::tuple<Heuristic, std::string>> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
-  std::string testCalibrationDir  = "../extern/calibration/";
+  std::string testCalibrationDir = "../extern/calibration/";
 
-  qc::QuantumComputation           qc;
-  std::string                      circuitName;
-  Architecture                     ibmqYorktown; // 5 qubits
-  Architecture                     ibmqLondon;   // 5 qubits (with calibration)
+  qc::QuantumComputation qc;
+  std::string circuitName;
+  Architecture ibmqYorktown; // 5 qubits
+  Architecture ibmqLondon;   // 5 qubits (with calibration)
   std::unique_ptr<HeuristicMapper> ibmqYorktownMapper;
   std::unique_ptr<HeuristicMapper> ibmqLondonMapper;
-  Architecture                     ibmQX5; // 16 qubits
+  Architecture ibmQX5; // 16 qubits
   std::unique_ptr<HeuristicMapper> ibmQX5Mapper;
-  Configuration                    settings{};
+  Configuration settings{};
 
   static const std::unordered_map<std::string,
                                   std::vector<std::vector<std::int16_t>>>
@@ -466,15 +466,15 @@ protected:
     ibmqLondon.loadCouplingMap(testArchitectureDir + "ibmq_london.arch");
     ibmqLondon.loadProperties(testCalibrationDir + "ibmq_london.csv");
     ibmqYorktownMapper = std::make_unique<HeuristicMapper>(qc, ibmqYorktown);
-    ibmqLondonMapper   = std::make_unique<HeuristicMapper>(qc, ibmqLondon);
+    ibmqLondonMapper = std::make_unique<HeuristicMapper>(qc, ibmqLondon);
     ibmQX5.loadCouplingMap(AvailableArchitecture::IbmQx5);
-    ibmQX5Mapper   = std::make_unique<HeuristicMapper>(qc, ibmQX5);
+    ibmQX5Mapper = std::make_unique<HeuristicMapper>(qc, ibmQX5);
     settings.debug = true;
     settings.automaticLayerSplits = false;
-    settings.initialLayout        = InitialLayout::Identity;
-    settings.layering             = Layering::Disjoint2qBlocks;
-    settings.lookaheadHeuristic   = LookaheadHeuristic::None;
-    settings.heuristic            = std::get<0>(GetParam());
+    settings.initialLayout = InitialLayout::Identity;
+    settings.layering = Layering::Disjoint2qBlocks;
+    settings.lookaheadHeuristic = LookaheadHeuristic::None;
+    settings.heuristic = std::get<0>(GetParam());
     settings.dataLoggingPath = "test_log/heur_properties_" + testName + "/";
   }
 };
@@ -803,8 +803,8 @@ TEST_P(TestHeuristics, HeuristicProperties) {
   // each node is at the position corresponding to its id; positions of unused
   // ids are filled with default values (i.e. node.id = 0)
   std::vector<std::vector<HeuristicMapper::Node>> allNodes{};
-  std::vector<std::string>                        layerNames{};
-  std::vector<std::size_t>                        finalSolutionIds{};
+  std::vector<std::string> layerNames{};
+  std::vector<std::size_t> finalSolutionIds{};
 
   // map to IBM Yorktown if possible
   if (qc.getNqubits() <= ibmqYorktown.getNqubits()) {
@@ -858,7 +858,7 @@ TEST_P(TestHeuristics, HeuristicProperties) {
   }
 
   for (std::size_t i = 0; i < allNodes.size(); ++i) {
-    auto& nodes           = allNodes.at(i);
+    auto& nodes = allNodes.at(i);
     auto& finalSolutionId = finalSolutionIds.at(i);
 
     if (finalSolutionId >= nodes.size() ||
@@ -978,7 +978,7 @@ TEST(Functionality, HeuristicBenchmark) {
     |   |
     0---1
   */
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
                           {3, 2}, {3, 4}, {4, 3}, {4, 0}, {0, 4}};
   architecture.loadCouplingMap(5, cm);
@@ -993,15 +993,15 @@ TEST(Functionality, HeuristicBenchmark) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
 
-  const auto    mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+  const auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
   Configuration settings{};
-  settings.heuristic                = Heuristic::GateCountMaxDistance;
-  settings.layering                 = Layering::DisjointQubits;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.preMappingOptimizations  = false;
+  settings.heuristic = Heuristic::GateCountMaxDistance;
+  settings.layering = Layering::DisjointQubits;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::None;
-  settings.debug                    = true;
+  settings.lookaheadHeuristic = LookaheadHeuristic::None;
+  settings.debug = true;
   mapper->map(settings);
   auto& result = mapper->getResults();
 
@@ -1054,7 +1054,7 @@ TEST(Functionality, HeuristicBenchmark) {
 TEST(Functionality, EmptyDump) {
   qc::QuantumComputation qc{1};
   qc.x(0);
-  Architecture    arch{1, {}};
+  Architecture arch{1, {}};
   HeuristicMapper mapper(qc, arch);
   mapper.dumpResult("test.qasm");
   mapper.map({});
@@ -1074,15 +1074,15 @@ TEST(Functionality, BenchmarkGeneratedNodes) {
   auto ibmQX5Mapper = std::make_unique<HeuristicMapper>(qc, ibmQX5);
 
   Configuration settings{};
-  settings.heuristic                = Heuristic::GateCountMaxDistance;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::None;
-  settings.layering                 = Layering::IndividualGates;
-  settings.automaticLayerSplits     = false;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.preMappingOptimizations  = false;
+  settings.heuristic = Heuristic::GateCountMaxDistance;
+  settings.lookaheadHeuristic = LookaheadHeuristic::None;
+  settings.layering = Layering::IndividualGates;
+  settings.automaticLayerSplits = false;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.useTeleportation         = false;
-  settings.debug                    = true;
+  settings.useTeleportation = false;
+  settings.debug = true;
   ibmQX5Mapper->map(settings);
   auto results = ibmQX5Mapper->getResults();
 
@@ -1094,13 +1094,13 @@ TEST(Functionality, InvalidSettings) {
   qc::QuantumComputation qc{1};
   qc.x(0);
   Architecture arch{1, {}};
-  auto         props = Architecture::Properties();
+  auto props = Architecture::Properties();
   props.setSingleQubitErrorRate(0, "x", 0.1);
   arch.loadProperties(props);
   HeuristicMapper mapper(qc, arch);
-  auto            config    = Configuration{};
-  config.method             = Method::Heuristic;
-  config.heuristic          = Heuristic::GateCountMaxDistance;
+  auto config = Configuration{};
+  config.method = Method::Heuristic;
+  config.heuristic = Heuristic::GateCountMaxDistance;
   config.lookaheadHeuristic = LookaheadHeuristic::GateCountMaxDistance;
   // invalid layering
   config.layering = Layering::OddGates;
@@ -1136,14 +1136,14 @@ TEST(Functionality, NoMeasurementsAdded) {
   HeuristicMapper mapper(qc, arch);
 
   // configure to not include measurements after mapping
-  auto config                           = Configuration{};
+  auto config = Configuration{};
   config.addMeasurementsToMappedCircuit = false;
 
   // perform the mapping
   mapper.map(config);
 
   // get the resulting circuit
-  auto              qcMapped = qc::QuantumComputation();
+  auto qcMapped = qc::QuantumComputation();
   std::stringstream qasm{};
   mapper.dumpResult(qasm, qc::Format::OpenQASM3);
   qcMapped.import(qasm, qc::Format::OpenQASM3);
@@ -1160,26 +1160,26 @@ TEST(Functionality, InvalidCircuits) {
   // architecture not connected
   qc::QuantumComputation qc{2U};
   qc.cx({0}, 1);
-  Architecture    arch{2U, {}};
+  Architecture arch{2U, {}};
   HeuristicMapper mapper(qc, arch);
   EXPECT_THROW(mapper.map(config), QMAPException);
 
   // gate with >1 control
   qc::QuantumComputation qc3{3U};
   qc3.mcx({0, 1}, 2);
-  Architecture    arch2{3U, {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 0}, {0, 2}}};
+  Architecture arch2{3U, {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 0}, {0, 2}}};
   HeuristicMapper mapper3(qc3, arch2);
   EXPECT_THROW(mapper3.map(config), QMAPException);
 }
 
 TEST(Functionality, DataLoggerAfterClose) {
-  const std::string      dataLoggingPath = "test_log/datalogger_after_close/";
+  const std::string dataLoggingPath = "test_log/datalogger_after_close/";
   qc::QuantumComputation qc{3};
   qc.x(0);
   Architecture arch{3, {}};
   auto dataLogger = std::make_unique<DataLogger>(dataLoggingPath, arch, qc);
   const qc::CompoundOperation compOp{};
-  Exchange                    teleport(0, 2, 1, qc::OpType::Teleportation);
+  Exchange teleport(0, 2, 1, qc::OpType::Teleportation);
   dataLogger->logSearchNode(0, 0, 0, 0., 0., 0., {}, false, {{teleport}}, 0);
   dataLogger->logSearchNode(1, 0, 0, 0., 0., 0., {}, false, {}, 0);
   dataLogger->splitLayer();
@@ -1209,7 +1209,7 @@ TEST(Functionality, DataLoggerAfterClose) {
 
 TEST(Functionality, DataLogger) {
   // setting up example architecture and circuit
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {1, 3}, {3, 1}};
   architecture.loadCouplingMap(4, cm);
 
@@ -1235,17 +1235,17 @@ TEST(Functionality, DataLogger) {
   qc.setName("test_circ");
 
   Configuration settings{};
-  settings.heuristic                = Heuristic::GateCountMaxDistance;
-  settings.layering                 = Layering::IndividualGates;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.preMappingOptimizations  = false;
+  settings.heuristic = Heuristic::GateCountMaxDistance;
+  settings.layering = Layering::IndividualGates;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::GateCountMaxDistance;
-  settings.nrLookaheads             = 1;
-  settings.firstLookaheadFactor     = 0.5;
-  settings.lookaheadFactor          = 0.9;
-  settings.debug                    = true;
-  settings.useTeleportation         = false;
+  settings.lookaheadHeuristic = LookaheadHeuristic::GateCountMaxDistance;
+  settings.nrLookaheads = 1;
+  settings.firstLookaheadFactor = 0.5;
+  settings.lookaheadFactor = 0.9;
+  settings.debug = true;
+  settings.useTeleportation = false;
   // setting data logging path to enable data logging
   settings.dataLoggingPath = "test_log/datalogger";
 
@@ -1320,7 +1320,7 @@ TEST(Functionality, DataLogger) {
     FAIL() << "Could not open file " << settings.dataLoggingPath
            << "/mapping_result.json";
   }
-  const auto  resultJson = nlohmann::basic_json<>::parse(resultFile);
+  const auto resultJson = nlohmann::basic_json<>::parse(resultFile);
   const auto& configJson = resultJson["config"];
   EXPECT_EQ(configJson["add_measurements_to_mapped_circuit"],
             settings.addMeasurementsToMappedCircuit);
@@ -1440,7 +1440,7 @@ TEST(Functionality, DataLogger) {
       FAIL() << "Could not open file " << settings.dataLoggingPath << "/layer_"
              << i << ".json";
     }
-    const auto        layerJson   = nlohmann::basic_json<>::parse(layerFile);
+    const auto layerJson = nlohmann::basic_json<>::parse(layerFile);
     const std::size_t finalNodeId = layerJson["final_node_id"];
     EXPECT_EQ(layerJson["initial_layout"].size(), architecture.getNqubits());
     EXPECT_EQ(layerJson["single_qubit_multiplicity"].size(),
@@ -1546,8 +1546,8 @@ TEST(Functionality, earlyTermination) {
     qc.measure(static_cast<qc::Qubit>(i), i);
   }
 
-  const CouplingMap        cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2},
-                                 {3, 4}, {4, 3}, {4, 5}, {5, 4}, {5, 6}, {6, 5}};
+  const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2},
+                          {3, 4}, {4, 3}, {4, 5}, {5, 4}, {5, 6}, {6, 5}};
   Architecture::Properties props{};
   props.setSingleQubitErrorRate(0, "x", 0.9);
   props.setSingleQubitErrorRate(1, "x", 0.5);
@@ -1562,23 +1562,23 @@ TEST(Functionality, earlyTermination) {
   Architecture arch{7, cm, props};
 
   Configuration config{};
-  config.method                        = Method::Heuristic;
-  config.layering                      = Layering::DisjointQubits;
-  config.initialLayout                 = InitialLayout::Identity;
-  config.automaticLayerSplits          = false;
+  config.method = Method::Heuristic;
+  config.layering = Layering::DisjointQubits;
+  config.initialLayout = InitialLayout::Identity;
+  config.automaticLayerSplits = false;
   config.iterativeBidirectionalRouting = false;
-  config.debug                         = true;
-  config.heuristic                     = Heuristic::FidelityBestLocation;
-  config.lookaheadHeuristic            = LookaheadHeuristic::None;
-  config.earlyTerminationLimit         = 4;
+  config.debug = true;
+  config.heuristic = Heuristic::FidelityBestLocation;
+  config.lookaheadHeuristic = LookaheadHeuristic::None;
+  config.earlyTerminationLimit = 4;
 
-  auto mapper             = std::make_unique<HeuristicMapper>(qc, arch);
+  auto mapper = std::make_unique<HeuristicMapper>(qc, arch);
   config.earlyTermination = EarlyTermination::None;
   mapper->map(config);
   auto results = mapper->getResults();
   EXPECT_FALSE(results.layerHeuristicBenchmark[0].earlyTermination);
 
-  mapper                  = std::make_unique<HeuristicMapper>(qc, arch);
+  mapper = std::make_unique<HeuristicMapper>(qc, arch);
   config.earlyTermination = EarlyTermination::ExpandedNodesAfterFirstSolution;
   mapper->map(config);
   results = mapper->getResults();
@@ -1595,14 +1595,14 @@ TEST(Functionality, earlyTermination) {
   EXPECT_EQ(
       results.layerHeuristicBenchmark[0].expandedNodesAfterOptimalSolution, 4);
 
-  mapper                  = std::make_unique<HeuristicMapper>(qc, arch);
+  mapper = std::make_unique<HeuristicMapper>(qc, arch);
   config.earlyTermination = EarlyTermination::ExpandedNodes;
   mapper->map(config);
   results = mapper->getResults();
   EXPECT_TRUE(results.layerHeuristicBenchmark[0].earlyTermination);
   EXPECT_EQ(results.layerHeuristicBenchmark[0].expandedNodes, 4);
 
-  mapper                  = std::make_unique<HeuristicMapper>(qc, arch);
+  mapper = std::make_unique<HeuristicMapper>(qc, arch);
   config.earlyTermination = EarlyTermination::SolutionNodes;
   mapper->map(config);
   results = mapper->getResults();
@@ -1669,7 +1669,7 @@ TEST(Functionality, InitialLayoutDump) {
                      {22, 23}, {24, 23}, {25, 24}, {26, 25}}};
 
   Configuration config{};
-  config.method   = Method::Heuristic;
+  config.method = Method::Heuristic;
   config.layering = Layering::Disjoint2qBlocks;
 
   HeuristicMapper mapper(qc, arch);
@@ -1679,17 +1679,17 @@ TEST(Functionality, InitialLayoutDump) {
   mapper.dumpResult(qasmStream, qc::Format::OpenQASM3);
   const std::string qasm = qasmStream.str();
 
-  qasmStream    = std::stringstream(qasm);
+  qasmStream = std::stringstream(qasm);
   auto qcMapped = qc::QuantumComputation();
   qcMapped.import(qasmStream, qc::Format::OpenQASM3);
 
   qasmStream = std::stringstream(qasm);
   std::string line;
-  bool        foundPermutation = false;
+  bool foundPermutation = false;
   while (std::getline(qasmStream, line)) {
     if (line.rfind("// i ", 0) == 0) {
-      std::stringstream          lineStream(line.substr(5));
-      std::string                entry;
+      std::stringstream lineStream(line.substr(5));
+      std::string entry;
       std::vector<std::uint32_t> qubits{};
       while (std::getline(lineStream, entry, ' ')) {
         EXPECT_NO_THROW(
@@ -1711,10 +1711,10 @@ TEST(Functionality, InitialLayoutDump) {
 
 class LayeringTest : public testing::Test {
 protected:
-  qc::QuantumComputation           qc;
-  Architecture                     arch;
+  qc::QuantumComputation qc;
+  Architecture arch;
   std::unique_ptr<HeuristicMapper> mapper;
-  Configuration                    settings{};
+  Configuration settings{};
 
   void SetUp() override {
     qc = qc::QuantumComputation{4, 4};
@@ -1731,12 +1731,12 @@ protected:
 
     arch = Architecture{4, {{0, 1}, {1, 2}, {2, 3}}};
 
-    settings.initialLayout                  = InitialLayout::Dynamic;
-    settings.preMappingOptimizations        = false;
-    settings.postMappingOptimizations       = false;
+    settings.initialLayout = InitialLayout::Dynamic;
+    settings.preMappingOptimizations = false;
+    settings.postMappingOptimizations = false;
     settings.addMeasurementsToMappedCircuit = true;
-    settings.addBarriersBetweenLayers       = true;
-    settings.automaticLayerSplits           = false;
+    settings.addBarriersBetweenLayers = true;
+    settings.automaticLayerSplits = false;
 
     mapper = std::make_unique<HeuristicMapper>(qc, arch);
   }
@@ -1748,7 +1748,7 @@ TEST_F(LayeringTest, Disjoint2qBlocks) {
   auto result = mapper->getResults();
   EXPECT_EQ(result.input.layers, 2);
   // get mapped circuit
-  auto              qcMapped = qc::QuantumComputation();
+  auto qcMapped = qc::QuantumComputation();
   std::stringstream qasm{};
   mapper->dumpResult(qasm, qc::Format::OpenQASM3);
   qcMapped.import(qasm, qc::Format::OpenQASM3);
@@ -1768,7 +1768,7 @@ TEST_F(LayeringTest, DisjointQubits) {
   auto result = mapper->getResults();
   EXPECT_EQ(result.input.layers, 3);
   // get mapped circuit
-  auto              qcMapped = qc::QuantumComputation();
+  auto qcMapped = qc::QuantumComputation();
   std::stringstream qasm{};
   mapper->dumpResult(qasm, qc::Format::OpenQASM3);
   qcMapped.import(qasm, qc::Format::OpenQASM3);
@@ -1788,7 +1788,7 @@ TEST_F(LayeringTest, IndividualGates) {
   auto result = mapper->getResults();
   EXPECT_EQ(result.input.layers, 6);
   // get mapped circuit
-  auto              qcMapped = qc::QuantumComputation();
+  auto qcMapped = qc::QuantumComputation();
   std::stringstream qasm{};
   mapper->dumpResult(qasm, qc::Format::OpenQASM3);
   qcMapped.import(qasm, qc::Format::OpenQASM3);
@@ -1804,16 +1804,16 @@ TEST_F(LayeringTest, IndividualGates) {
 
 class HeuristicTest5Q : public testing::TestWithParam<std::string> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
-  std::string testCalibrationDir  = "../extern/calibration/";
+  std::string testCalibrationDir = "../extern/calibration/";
 
-  qc::QuantumComputation           qc;
-  Architecture                     ibmqYorktown;
-  Architecture                     ibmqLondon;
+  qc::QuantumComputation qc;
+  Architecture ibmqYorktown;
+  Architecture ibmqLondon;
   std::unique_ptr<HeuristicMapper> ibmqYorktownMapper;
   std::unique_ptr<HeuristicMapper> ibmqLondonMapper;
-  Configuration                    settings{};
+  Configuration settings{};
 
   void SetUp() override {
     qc.import(testExampleDir + GetParam() + ".qasm");
@@ -1821,11 +1821,11 @@ protected:
     ibmqLondon.loadCouplingMap(testArchitectureDir + "ibmq_london.arch");
     ibmqLondon.loadProperties(testCalibrationDir + "ibmq_london.csv");
     ibmqYorktownMapper = std::make_unique<HeuristicMapper>(qc, ibmqYorktown);
-    ibmqLondonMapper   = std::make_unique<HeuristicMapper>(qc, ibmqLondon);
-    settings.verbose   = true;
-    settings.debug     = true;
+    ibmqLondonMapper = std::make_unique<HeuristicMapper>(qc, ibmqLondon);
+    settings.verbose = true;
+    settings.debug = true;
 
-    settings.iterativeBidirectionalRouting       = true;
+    settings.iterativeBidirectionalRouting = true;
     settings.iterativeBidirectionalRoutingPasses = 3;
   }
 };
@@ -1878,18 +1878,18 @@ TEST_P(HeuristicTest5Q, Dynamic) {
 
 class HeuristicTest16Q : public testing::TestWithParam<std::string> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
 
-  qc::QuantumComputation           qc;
-  Architecture                     ibmQX5;
+  qc::QuantumComputation qc;
+  Architecture ibmQX5;
   std::unique_ptr<HeuristicMapper> ibmQX5Mapper;
-  Configuration                    settings{};
+  Configuration settings{};
 
   void SetUp() override {
     qc.import(testExampleDir + GetParam() + ".qasm");
     ibmQX5.loadCouplingMap(AvailableArchitecture::IbmQx5);
-    ibmQX5Mapper   = std::make_unique<HeuristicMapper>(qc, ibmQX5);
+    ibmQX5Mapper = std::make_unique<HeuristicMapper>(qc, ibmQX5);
     settings.debug = true;
   }
 };
@@ -1929,11 +1929,11 @@ TEST_P(HeuristicTest16Q, Disjoint2qBlocks) {
 
 class HeuristicTest20Q : public testing::TestWithParam<std::string> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
 
-  qc::QuantumComputation           qc;
-  Architecture                     arch;
+  qc::QuantumComputation qc;
+  Architecture arch;
   std::unique_ptr<HeuristicMapper> tokyoMapper;
 
   void SetUp() override {
@@ -1956,7 +1956,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(HeuristicTest20Q, Dynamic) {
   Configuration settings{};
   settings.initialLayout = InitialLayout::Dynamic;
-  settings.debug         = true;
+  settings.debug = true;
   tokyoMapper->map(settings);
   tokyoMapper->dumpResult(GetParam() + "_heuristic_tokyo_dynamic.qasm");
   tokyoMapper->printResult(std::cout);
@@ -1966,11 +1966,11 @@ TEST_P(HeuristicTest20Q, Dynamic) {
 class HeuristicTest20QTeleport
     : public testing::TestWithParam<std::tuple<std::uint64_t, std::string>> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
 
-  qc::QuantumComputation           qc;
-  Architecture                     arch;
+  qc::QuantumComputation qc;
+  Architecture arch;
   std::unique_ptr<HeuristicMapper> tokyoMapper;
 
   void SetUp() override {
@@ -1995,8 +1995,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(HeuristicTest20QTeleport, Teleportation) {
   Configuration settings{};
-  settings.initialLayout       = InitialLayout::Dynamic;
-  settings.debug               = true;
+  settings.initialLayout = InitialLayout::Dynamic;
+  settings.debug = true;
   settings.teleportationQubits = std::min(
       (arch.getNqubits() - qc.getNqubits()) & ~1U, static_cast<std::size_t>(8));
   settings.teleportationSeed = std::get<0>(GetParam());
@@ -2009,13 +2009,13 @@ TEST_P(HeuristicTest20QTeleport, Teleportation) {
 
 class HeuristicTestFidelity : public testing::TestWithParam<std::string> {
 protected:
-  std::string testExampleDir      = "../examples/";
+  std::string testExampleDir = "../examples/";
   std::string testArchitectureDir = "../extern/architectures/";
-  std::string testCalibrationDir  = "../extern/calibration/";
+  std::string testCalibrationDir = "../extern/calibration/";
 
-  qc::QuantumComputation           qc;
-  Architecture                     arch;
-  Architecture                     nonFidelityArch;
+  qc::QuantumComputation qc;
+  Architecture arch;
+  Architecture nonFidelityArch;
   std::unique_ptr<HeuristicMapper> mapper;
   std::unique_ptr<HeuristicMapper> nonFidelityMapper;
 
@@ -2041,9 +2041,9 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(HeuristicTestFidelity, Identity) {
   Configuration settings{};
-  settings.layering           = Layering::DisjointQubits;
-  settings.initialLayout      = InitialLayout::Identity;
-  settings.heuristic          = Heuristic::FidelityBestLocation;
+  settings.layering = Layering::DisjointQubits;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.heuristic = Heuristic::FidelityBestLocation;
   settings.lookaheadHeuristic = LookaheadHeuristic::None;
   mapper->map(settings);
   mapper->dumpResult(GetParam() + "_heuristic_london_fidelity_identity.qasm");
@@ -2053,9 +2053,9 @@ TEST_P(HeuristicTestFidelity, Identity) {
 
 TEST_P(HeuristicTestFidelity, Static) {
   Configuration settings{};
-  settings.layering           = Layering::DisjointQubits;
-  settings.initialLayout      = InitialLayout::Static;
-  settings.heuristic          = Heuristic::FidelityBestLocation;
+  settings.layering = Layering::DisjointQubits;
+  settings.initialLayout = InitialLayout::Static;
+  settings.heuristic = Heuristic::FidelityBestLocation;
   settings.lookaheadHeuristic = LookaheadHeuristic::None;
   mapper->map(settings);
   mapper->dumpResult(GetParam() + "_heuristic_london_fidelity_static.qasm");
@@ -2065,9 +2065,9 @@ TEST_P(HeuristicTestFidelity, Static) {
 
 TEST_P(HeuristicTestFidelity, Dynamic) {
   Configuration settings{};
-  settings.layering           = Layering::DisjointQubits;
-  settings.initialLayout      = InitialLayout::Dynamic;
-  settings.heuristic          = Heuristic::FidelityBestLocation;
+  settings.layering = Layering::DisjointQubits;
+  settings.initialLayout = InitialLayout::Dynamic;
+  settings.heuristic = Heuristic::FidelityBestLocation;
   settings.lookaheadHeuristic = LookaheadHeuristic::None;
   mapper->map(settings);
   mapper->dumpResult(GetParam() + "_heuristic_london_fidelity_static.qasm");
@@ -2077,15 +2077,15 @@ TEST_P(HeuristicTestFidelity, Dynamic) {
 
 TEST_P(HeuristicTestFidelity, NoFidelity) {
   Configuration settings{};
-  settings.layering           = Layering::DisjointQubits;
-  settings.initialLayout      = InitialLayout::Static;
-  settings.heuristic          = Heuristic::FidelityBestLocation;
+  settings.layering = Layering::DisjointQubits;
+  settings.initialLayout = InitialLayout::Static;
+  settings.heuristic = Heuristic::FidelityBestLocation;
   settings.lookaheadHeuristic = LookaheadHeuristic::None;
   EXPECT_THROW(nonFidelityMapper->map(settings), QMAPException);
 }
 
 TEST(HeuristicTestFidelity, RemapSingleQubit) {
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {
       {0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3},
       {3, 2}, {3, 4}, {4, 3}, {4, 5}, {5, 4},
@@ -2132,14 +2132,14 @@ TEST(HeuristicTestFidelity, RemapSingleQubit) {
   auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
 
   Configuration settings{};
-  settings.layering                 = Layering::Disjoint2qBlocks;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.heuristic                = Heuristic::FidelityBestLocation;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::None;
-  settings.preMappingOptimizations  = false;
+  settings.layering = Layering::Disjoint2qBlocks;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.heuristic = Heuristic::FidelityBestLocation;
+  settings.lookaheadHeuristic = LookaheadHeuristic::None;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.verbose                  = true;
-  settings.swapOnFirstLayer         = true;
+  settings.verbose = true;
+  settings.swapOnFirstLayer = true;
   mapper->map(settings);
   mapper->dumpResult("remap_single_qubit_mapped.qasm");
   mapper->printResult(std::cout);
@@ -2170,7 +2170,7 @@ TEST(HeuristicTestFidelity, RemapSingleQubit) {
 }
 
 TEST(HeuristicTestFidelity, QubitRideAlong) {
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}, {2, 3}, {3, 2},
                           {1, 4}, {4, 1}, {2, 5}, {5, 2}, {5, 6}, {6, 5}};
   architecture.loadCouplingMap(7, cm);
@@ -2217,14 +2217,14 @@ TEST(HeuristicTestFidelity, QubitRideAlong) {
   auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
 
   Configuration settings{};
-  settings.layering                 = Layering::Disjoint2qBlocks;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.heuristic                = Heuristic::FidelityBestLocation;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::None;
-  settings.preMappingOptimizations  = false;
+  settings.layering = Layering::Disjoint2qBlocks;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.heuristic = Heuristic::FidelityBestLocation;
+  settings.lookaheadHeuristic = LookaheadHeuristic::None;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.verbose                  = true;
-  settings.swapOnFirstLayer         = true;
+  settings.verbose = true;
+  settings.swapOnFirstLayer = true;
   mapper->map(settings);
   mapper->dumpResult("qubit_ride_along_mapped.qasm");
   mapper->printResult(std::cout);
@@ -2252,7 +2252,7 @@ TEST(HeuristicTestFidelity, QubitRideAlong) {
 }
 
 TEST(HeuristicTestFidelity, SingleQubitsCompete) {
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {{0, 1}, {1, 0}, {1, 2}, {2, 1}};
   architecture.loadCouplingMap(3, cm);
 
@@ -2279,14 +2279,14 @@ TEST(HeuristicTestFidelity, SingleQubitsCompete) {
   auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
 
   Configuration settings{};
-  settings.layering                 = Layering::Disjoint2qBlocks;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.heuristic                = Heuristic::FidelityBestLocation;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::None;
-  settings.preMappingOptimizations  = false;
+  settings.layering = Layering::Disjoint2qBlocks;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.heuristic = Heuristic::FidelityBestLocation;
+  settings.lookaheadHeuristic = LookaheadHeuristic::None;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.verbose                  = true;
-  settings.swapOnFirstLayer         = true;
+  settings.verbose = true;
+  settings.swapOnFirstLayer = true;
   mapper->map(settings);
   mapper->dumpResult("single_qubits_compete.qasm");
   mapper->printResult(std::cout);
@@ -2302,7 +2302,7 @@ TEST(HeuristicTestFidelity, SingleQubitsCompete) {
 }
 
 TEST(HeuristicTestFidelity, LayerSplitting) {
-  Architecture      architecture{};
+  Architecture architecture{};
   const CouplingMap cm = {
       {0, 1}, {1, 0}, {1, 2},  {2, 1},  {2, 3},   {3, 2},
 
@@ -2396,15 +2396,15 @@ TEST(HeuristicTestFidelity, LayerSplitting) {
   auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
 
   Configuration settings{};
-  settings.verbose                  = true;
-  settings.layering                 = Layering::Disjoint2qBlocks;
-  settings.initialLayout            = InitialLayout::Identity;
-  settings.heuristic                = Heuristic::FidelityBestLocation;
-  settings.lookaheadHeuristic       = LookaheadHeuristic::None;
-  settings.preMappingOptimizations  = false;
+  settings.verbose = true;
+  settings.layering = Layering::Disjoint2qBlocks;
+  settings.initialLayout = InitialLayout::Identity;
+  settings.heuristic = Heuristic::FidelityBestLocation;
+  settings.lookaheadHeuristic = LookaheadHeuristic::None;
+  settings.preMappingOptimizations = false;
   settings.postMappingOptimizations = false;
-  settings.swapOnFirstLayer         = true;
-  settings.automaticLayerSplits     = true;
+  settings.swapOnFirstLayer = true;
+  settings.automaticLayerSplits = true;
   settings.automaticLayerSplitsNodeLimit =
       1; // force splittings after 1st expanded node until layers are
          // unsplittable
@@ -2487,7 +2487,7 @@ TEST(HeuristicTestFidelity, LayerSplitting) {
       if (line.empty()) {
         continue;
       }
-      std::string       col;
+      std::string col;
       std::stringstream lineStream(line);
       if (!std::getline(lineStream, col, ';')) {
         FAIL() << "Missing value for node id in " << settings.dataLoggingPath

--- a/test/test_logicblocks.cpp
+++ b/test/test_logicblocks.cpp
@@ -2,11 +2,11 @@
 #include "Encodings.hpp"
 #include "Logic.hpp"
 #include "LogicTerm.hpp"
+#include "Model.hpp"
 #include "Z3Logic.hpp"
-#include "Z3Model.hpp"
 
-#include "gtest/gtest.h"
 #include <cstddef>
+#include <gtest/gtest.h>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/test/test_logicblocks.cpp
+++ b/test/test_logicblocks.cpp
@@ -19,8 +19,8 @@ class TestZ3 : public testing::TestWithParam<logicbase::OpType> {
 protected:
   void SetUp() override {}
 
-  std::shared_ptr<z3::context> ctx    = std::make_shared<z3::context>();
-  std::shared_ptr<z3::solver>  solver = std::make_shared<z3::solver>(*ctx);
+  std::shared_ptr<z3::context> ctx = std::make_shared<z3::context>();
+  std::shared_ptr<z3::solver> solver = std::make_shared<z3::solver>(*ctx);
 };
 TEST_F(TestZ3, ConstructDestruct) {
   std::unique_ptr<z3logic::Z3LogicBlock> const z3logic =
@@ -104,9 +104,9 @@ TEST_F(TestZ3, SimpleTrue) {
   EXPECT_EQ(z3logic.solve(), Result::SAT);
   z3logic.reset();
 
-  a                 = z3logic.makeVariable("a", CType::BOOL);
-  b                 = z3logic.makeVariable("b", CType::BOOL);
-  c                 = z3logic.makeVariable("c", CType::BOOL);
+  a = z3logic.makeVariable("a", CType::BOOL);
+  b = z3logic.makeVariable("b", CType::BOOL);
+  c = z3logic.makeVariable("c", CType::BOOL);
   LogicTerm const d = z3logic.makeVariable("d", CType::BOOL);
   z3logic.assertFormula((a && b) || (c && d));
   z3logic.produceInstance();
@@ -318,9 +318,9 @@ TEST_F(TestZ3, IntNumbers) {
   z3logic.reset();
 
   LogicTerm boolA = z3logic.makeVariable("bool_a", CType::BOOL);
-  a               = z3logic.makeVariable("a", CType::INT);
-  b               = z3logic.makeVariable("b", CType::INT);
-  c               = z3logic.makeVariable("c", CType::INT);
+  a = z3logic.makeVariable("a", CType::INT);
+  b = z3logic.makeVariable("b", CType::INT);
+  c = z3logic.makeVariable("c", CType::INT);
   z3logic.assertFormula(a == LogicTerm(3));
   z3logic.assertFormula(b == LogicTerm(2));
   z3logic.assertFormula(c == LogicTerm(1));
@@ -330,9 +330,9 @@ TEST_F(TestZ3, IntNumbers) {
   z3logic.reset();
 
   boolA = z3logic.makeVariable("bool_a", CType::BOOL);
-  a     = z3logic.makeVariable("a", CType::INT);
-  b     = z3logic.makeVariable("b", CType::INT);
-  c     = z3logic.makeVariable("c", CType::INT);
+  a = z3logic.makeVariable("a", CType::INT);
+  b = z3logic.makeVariable("b", CType::INT);
+  c = z3logic.makeVariable("c", CType::INT);
   z3logic.assertFormula(a == LogicTerm(3));
   z3logic.assertFormula(b == LogicTerm(2));
   z3logic.assertFormula(c == LogicTerm(1));
@@ -557,7 +557,7 @@ class TestZ3Opt : public testing::TestWithParam<logicbase::OpType> {
 protected:
   void SetUp() override {}
 
-  std::shared_ptr<z3::context>  ctx = std::make_shared<z3::context>();
+  std::shared_ptr<z3::context> ctx = std::make_shared<z3::context>();
   std::shared_ptr<z3::optimize> opt = std::make_shared<z3::optimize>(*ctx);
 };
 
@@ -880,9 +880,9 @@ TEST_F(TestZ3Opt, IntNumbers) {
   z3logic->reset();
 
   LogicTerm boolA = z3logic->makeVariable("bool_a", CType::BOOL);
-  a               = z3logic->makeVariable("a", CType::INT);
-  b               = z3logic->makeVariable("b", CType::INT);
-  c               = z3logic->makeVariable("c", CType::INT);
+  a = z3logic->makeVariable("a", CType::INT);
+  b = z3logic->makeVariable("b", CType::INT);
+  c = z3logic->makeVariable("c", CType::INT);
   z3logic->assertFormula(a == LogicTerm(3));
   z3logic->assertFormula(b == LogicTerm(2));
   z3logic->assertFormula(c == LogicTerm(1));
@@ -893,9 +893,9 @@ TEST_F(TestZ3Opt, IntNumbers) {
   z3logic->reset();
 
   boolA = z3logic->makeVariable("bool_a", CType::BOOL);
-  a     = z3logic->makeVariable("a", CType::INT);
-  b     = z3logic->makeVariable("b", CType::INT);
-  c     = z3logic->makeVariable("c", CType::INT);
+  a = z3logic->makeVariable("a", CType::INT);
+  b = z3logic->makeVariable("b", CType::INT);
+  c = z3logic->makeVariable("c", CType::INT);
   z3logic->assertFormula(a == LogicTerm(3));
   z3logic->assertFormula(b == LogicTerm(2));
   z3logic->assertFormula(c == LogicTerm(1));

--- a/test/test_tableau.cpp
+++ b/test/test_tableau.cpp
@@ -83,12 +83,12 @@ TEST_F(TestTableau, InitialTableau) {
   const auto fullTFromStr = Tableau(fullRepresentation);
   EXPECT_EQ(fullTableau, fullTFromStr);
 
-  const std::string stabilizers      = "[+ZI, +IZ]";
-  const auto        tFromStabilizers = Tableau(stabilizers);
+  const std::string stabilizers = "[+ZI, +IZ]";
+  const auto tFromStabilizers = Tableau(stabilizers);
   EXPECT_EQ(tableau, tFromStabilizers);
 
   const std::string destabilizers = "[+XI, +IX]";
-  const auto        fullTFromStabilizersAndDestabilizers =
+  const auto fullTFromStabilizersAndDestabilizers =
       Tableau(stabilizers, destabilizers);
   EXPECT_EQ(fullTableau, fullTFromStabilizersAndDestabilizers);
 }

--- a/test/test_tableau.cpp
+++ b/test/test_tableau.cpp
@@ -5,9 +5,19 @@
 
 #include "QuantumComputation.hpp"
 #include "cliffordsynthesis/Tableau.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 #include "utils.hpp"
 
-#include "gtest/gtest.h"
+#include <bitset>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 
 namespace cs {
 


### PR DESCRIPTION
## Description

This PR aims to fix all the new warnings that were introduced in clang-tidy versions 18, which have been enabled with the switch to the `mqt-workflows@v1.0.0`.

The first commit, which will later be reverted, just triggers a full clang-tidy run on the whole codebase.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.