### PR TITLE
Keep na arch alive 2

### DIFF
--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -847,7 +847,8 @@ PYBIND11_MODULE(pyqmap, m) {
       "Neutral Atom Hybrid Mapper that can use both SWAP gates and AOD "
       "movements to map a quantum circuit to a neutral atom quantum computer.")
       .def(py::init<const na::NeutralAtomArchitecture&, na::MapperParameters>(),
-           "Create Hybrid NA Mapper with mapper parameters", "arch"_a,
+           "Create Hybrid NA Mapper with mapper parameters",
+           py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), "arch"_a,
            "params"_a = na::MapperParameters())
       .def("set_parameters", &na::NeutralAtomMapper::setParameters,
            "Set the parameters for the Hybrid NA Mapper", "params"_a)

--- a/test/python/test_hybridmap.py
+++ b/test/python/test_hybridmap.py
@@ -57,3 +57,24 @@ def test_hybrid_na_mapper(
     assert results["totalExecutionTime"] > 0
     assert results["totalIdleTime"] > 0
     assert results["totalFidelities"] > 0
+
+
+def _nested_mapper_create() -> HybridNAMapper:
+    """Create a nested Neutral Atom hybrid architecture."""
+    arch = NeutralAtomHybridArchitecture(str(arch_dir / "rubidium.json"))
+    params = HybridMapperParameters()
+    return HybridNAMapper(arch, params=params)
+
+
+def test_keep_alive() -> None:
+    """Test the keep alive feature of the python bindings."""
+    mapper = _nested_mapper_create()
+
+    qc = QuantumCircuit.from_qasm_file(str(circuit_dir / "dj_nativegates_rigetti_qiskit_opt3_10.qasm"))
+
+    mapper.map(qc)
+    results = mapper.schedule(create_animation_csv=False)
+
+    assert results["totalExecutionTime"] > 0
+    assert results["totalIdleTime"] > 0
+    assert results["totalFidelities"] > 0


### PR DESCRIPTION
## Description

This fixed the problem that for the Hybridmapper, using the Python bindings it can happen that the architecture object is deleted by the garbage collector, loosing the reference for the mapper. Now it is kept alive using the keep_alive functionality of PyBind.


## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.