### PR TITLE
⚡🔧 Faster cibuildwheel and better Windows wheel repair

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@dependabot/github_actions/github-actions-dfafb25d9f
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.0
     with:
       setup-z3: true
       z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@dependabot/github_actions/github-actions-dfafb25d9f
     with:
       setup-z3: true
       z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.0
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.0
     with:
       setup-z3: true
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.0
     with:
       setup-z3: true
 
@@ -36,7 +36,7 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.0
     with:
       setup-z3: true
 
@@ -44,7 +44,7 @@ jobs:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.0
     with:
       setup-z3: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ skip = "*-musllinux*"
 archs = "auto64"
 test-command = "python -c \"from mqt import qmap\""
 test-skip = "cp38-macosx_arm64"
-build-frontend = "build"
+build-frontend = "build[uv]"
 
 [tool.cibuildwheel.linux]
 environment = { Z3_ROOT="/opt/python/cp311-cp311/lib/python3.11/site-packages/z3", DEPLOY="ON" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,6 @@ repair-wheel-command = [
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel"
-repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel}"
+before-build = "pip install delvewheel>=1.4.0"
+repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_GENERATOR = "Ninja" }


### PR DESCRIPTION
## Description

This PR makes use of `cibuildwheel`'s latest addition of a `build[uv]` build frontend option that uses `uv` under the hood to speed up the build process.
Furthermore, it adjusts the Windows repair command to respect namespace packages.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
