### PR TITLE
⬆️ update mqt-workflows to 1.1.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.2
     with:
       setup-z3: true
       z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.1
     with:
       setup-z3: true
       z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.3
     with:
       setup-z3: true
       z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.2
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.2
     with:
       setup-z3: true
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.2
     with:
       setup-z3: true
 
@@ -36,7 +36,7 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.2
     with:
       setup-z3: true
 
@@ -44,7 +44,7 @@ jobs:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.2
     with:
       setup-z3: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.1
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.1
     with:
       setup-z3: true
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.1
     with:
       setup-z3: true
 
@@ -36,7 +36,7 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.1
     with:
       setup-z3: true
 
@@ -44,7 +44,7 @@ jobs:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.1
     with:
       setup-z3: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.3
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.3
     with:
       setup-z3: true
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.3
     with:
       setup-z3: true
 
@@ -36,7 +36,7 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.3
     with:
       setup-z3: true
 
@@ -44,7 +44,7 @@ jobs:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.3
     with:
       setup-z3: true
 

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -4,6 +4,12 @@ on:
     # run once a month on the first day of the month at 00:00 UTC
     - cron: "0 0 1 * *"
   workflow_dispatch:
+    inputs:
+      update-to-head:
+        description: "Update to the latest commit on the default branch"
+        type: boolean
+        required: false
+        default: false
   pull_request:
     paths:
       - .github/workflows/update-mqt-core.yml
@@ -11,6 +17,6 @@ on:
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.1
-    secrets:
-      token: ${{ github.token }}
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.2
+    with:
+      update-to-head: ${{ github.event.inputs.update-to-head || false }}

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -11,4 +11,6 @@ on:
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.1
+    secrets:
+      token: ${{ github.token }}

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -14,9 +14,13 @@ on:
     paths:
       - .github/workflows/update-mqt-core.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.3
     with:
       update-to-head: ${{ github.event.inputs.update-to-head || false }}


### PR DESCRIPTION
## Description

This PR updates the mqt-workflows to their latest version. The only real change is that the MQT Core update workflow now requires a token.
For the moment, the token being used is the regular GitHub token, which means that the resulting PRs won't automatically trigger CI runs.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
