### PR TITLE
📦 add artifact attestation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,8 @@ jobs:
       url: https://pypi.org/p/mqt.qmap
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [python-packaging]
     steps:
       - uses: actions/download-artifact@v4
@@ -31,4 +33,8 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
+      - name: Generate artifact attestation for sdist and wheel(s)
+        uses: actions/attest-build-provenance@v1.3.2
+        with:
+          subject-path: "dist/*"
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,7 @@ repos:
           - importlib_resources
           - numpy
           - pytest
+          - rustworkx
           - mqt.qcec
 
   # Check for spelling

--- a/src/mqt/qmap/subarchitectures.py
+++ b/src/mqt/qmap/subarchitectures.py
@@ -255,7 +255,7 @@ class SubarchitectureOrder:
         colors = [SubarchitectureOrder.inactive_color for _ in range(self.arch.num_nodes())]
         for node in subarchitecture.nodes():
             colors[node] = SubarchitectureOrder.active_color
-        return rxviz.mpl_draw(self.arch, node_color=colors)  # type: ignore[call-arg]
+        return rxviz.mpl_draw(self.arch, node_color=colors)
 
     def draw_subarchitectures(self, subarchitectures: list[Graph] | list[tuple[int, int]]) -> list[figure.Figure]:
         """Create matplotlib figures showing subarchitectures within the entire architecture.


### PR DESCRIPTION
## Description

This PR enables artifact attestations for the sdist and wheels produced via the continous deployment job.
This allows users to verify that the artifacts were built using our GitHub Action.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
