### PR TITLE
⬆️ update mqt-workflows to v1.3 (moving tag)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.3
     with:
       setup-z3: true
       z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.3
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.3
     with:
       setup-z3: true
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.3
     with:
       setup-z3: true
 
@@ -36,7 +36,7 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.3
     with:
       skip-testing-latest-python: true
       setup-z3: true
@@ -45,7 +45,7 @@ jobs:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.3
     with:
       setup-z3: true
 

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -21,6 +21,6 @@ concurrency:
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.2.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.3
     with:
       update-to-head: ${{ github.event.inputs.update-to-head || false }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ cmake.version = ">=3.19"
 ninja.version = ">=1.10"
 
 # Setuptools-style build caching in a local directory
-build-dir = "build/{wheel_tag}"
+build-dir = "build/{build_type}"
 
 # Explicitly set the package directory
 wheel.packages = ["src/mqt"]
@@ -283,4 +283,4 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel>=1.7.3"
 repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
-environment = { CMAKE_GENERATOR = "Ninja" }
+environment = { CMAKE_GENERATOR = "Ninja", SKBUILD_CMAKE_ARGS="--fresh" }


### PR DESCRIPTION
## Description

This PR updates the MQT workflows to `v1.3`, which is the first version to offer moving minor tags that should reduce the update frequency.
Furthermore, the updated workflows combine the emulated wheel jobs to reduce overall build time and reduce the number of parallel jobs.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
