### PR TITLE
🐍 Fix mapping for circuits with more than 128 qubits

### DIFF
--- a/test/sc/heuristic/test_heuristic.cpp
+++ b/test/sc/heuristic/test_heuristic.cpp
@@ -2526,3 +2526,29 @@ TEST(HeuristicTestFidelity, LayerSplitting) {
            << " does not exist";
   }
 }
+
+TEST(HeuristicDebug, MoreThan128Qubits) {
+  const std::size_t num_qubits = 129;
+
+  // create a linear NN coupling map
+  CouplingMap cm = {};
+  for (std::size_t i = 0; i < num_qubits - 1; ++i) {
+    cm.emplace(i, i + 1);
+    cm.emplace(i + 1, i);
+  }
+  Architecture architecture{num_qubits, cm};
+
+  // create a simple circuit to map to the architecture
+  auto qc = qc::QuantumComputation(num_qubits);
+  for (std::size_t i = 0; i < num_qubits - 1; ++i) {
+    qc.cx(static_cast<qc::Qubit>(i), static_cast<qc::Qubit>(i + 1));
+  }
+
+  auto mapper = std::make_unique<HeuristicMapper>(qc, architecture);
+
+  Configuration settings{};
+
+  settings.verbose = true;
+  mapper->map(settings);
+  mapper->printResult(std::cout);
+}


### PR DESCRIPTION
## Description

Trying to map a circuit consisting of more than 128 qubits currently leads to an out-of-bounds exception being thrown.
This PR aims to address this issue.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
