### PR TITLE
⚗️ upload to Test PyPI for pushes on `main`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,24 +1,50 @@
 name: CD
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/workflows/cd.yml
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
 
 jobs:
+  # Builds the sdist and wheels on all supported platforms and uploads the resulting
+  # wheels as GitHub artifacts `dev-cibw-*`, `test-cibw-*`, or `cibw-*`, depending on
+  # whether the workflow is triggered from a PR, a push to main, or a release, respectively.
   python-packaging:
     name: 🐍 Packaging
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
     with:
-      setup-z3: true
-      z3-version: 4.12.6 # 4.13.0 has incorrectly tagged manylinux wheels
+      # Do not include local version information on pushes to main to facilitate TestPyPI uploads.
+      no-local-version: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      # Do not build emulated wheels on pushes to main to reduce runner load for CD.
+      build-emulated-wheels: ${{ github.ref != 'refs/heads/main' || github.event_name != 'push' }}
 
+  # Downloads the previously generated artifacts and deploys to TestPyPI on pushes to main
+  deploy-test-pypi:
+    name: 🚀 Deploy to Test PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/mqt.qmap
+    needs: [python-packaging]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: test-cibw-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true
+
+  # Downloads the previously generated artifacts and deploys to PyPI on published releases.
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'
     name: 🚀 Deploy to PyPI
@@ -26,10 +52,6 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/mqt.qmap
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
     needs: [python-packaging]
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,10 @@ jobs:
       no-local-version: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
       # Do not build emulated wheels on pushes to main to reduce runner load for CD.
       build-emulated-wheels: ${{ github.ref != 'refs/heads/main' || github.event_name != 'push' }}
+      # Make sure Z3 is available
+      setup-z3: true
+      # 4.13.0 has incorrectly tagged manylinux wheels
+      z3-version: 4.12.6
 
   # Downloads the previously generated artifacts and deploys to TestPyPI on pushes to main
   deploy-test-pypi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cd)
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
+    with:
+      setup-z3: true
+      # 4.13.0 has incorrectly tagged manylinux wheels
+      z3-version: 4.12.6
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
     with:
       setup-z3: true
 
+  cd:
+    name: 🚀 CD
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.run-cd)
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
+
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check
     if: always()
@@ -57,6 +63,7 @@ jobs:
       - cpp-linter
       - python-tests
       - code-ql
+      - cd
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
@@ -78,5 +85,9 @@ jobs:
             ${{
               fromJSON(needs.change-detection.outputs.run-code-ql)
               && '' || 'code-ql,'
+            }}
+            ${{
+              fromJSON(needs.change-detection.outputs.run-cd)
+              && '' || 'cd,'
             }}
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -23,4 +23,4 @@ jobs:
     name: ⬆️ Update MQT Core
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.4
     with:
-      update-to-head: ${{ github.event.inputs.update-to-head || false }}
+      update-to-head: ${{ github.event.inputs.update-to-head == 'true' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,10 @@ before-build = "pip install delvewheel>=1.7.3"
 repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_GENERATOR = "Ninja", SKBUILD_CMAKE_ARGS="--fresh" }
 
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+
 
 [tool.uv]
 reinstall-package = ["mqt.qmap"]


### PR DESCRIPTION
## Description

This PR updates the CD workflow so that anytime it runs on a push to `main`, it uploads the resulting package to Test PyPI. This allows to battle test the packages before official releases.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.