### PR TITLE
🩹 fix missing support for identity gates in Clifford tableau simulation

### DIFF
--- a/src/cliffordsynthesis/Tableau.cpp
+++ b/src/cliffordsynthesis/Tableau.cpp
@@ -117,6 +117,8 @@ void Tableau::applyGate(const qc::Operation* const gate) {
   // non-controlled gates
   if (!gate->isControlled()) {
     switch (gate->getType()) {
+    case qc::OpType::I:
+      break;
     case qc::OpType::H:
       applyH(target);
       break;

--- a/test/cliffordsynthesis/test_tableau.cpp
+++ b/test/cliffordsynthesis/test_tableau.cpp
@@ -510,6 +510,7 @@ TEST_F(TestTableau, CircuitTranslation) {
   using namespace qc::literals;
 
   qc::QuantumComputation qc(2U);
+  qc.i(0);
   qc.x(0);
   qc.y(0);
   qc.z(0);


### PR DESCRIPTION
## Description

The Clifford tableau simulation was missing support for simulating identity gates/
This PR adds the corresponding (trivial) functionality.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
