### PR TITLE
🧹 Simplify cibuildwheel v4 configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,7 @@ PC170 = "We do not use rST files anymore"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["*-musllinux_*", "cp313t-*"]
+skip = ["*-musllinux_*"]
 archs = "auto64"
 test-groups = ["test"]
 test-command = "pytest {project}/test/python"
@@ -350,12 +350,6 @@ repair-wheel-command = """delvewheel repair -w {dest_dir} {wheel} --namespace-pk
 --exclude mqt-core-ds.dll \
 --exclude mqt-core-na.dll \
 --exclude spdlog.dll"""
-
-[[tool.cibuildwheel.overrides]]
-select = "cp312-*"
-inherit.repair-wheel-command = "append"
-repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
-
 
 [tool.uv]
 required-version = ">=0.5.20"


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Simplify the cibuildwheel configuration after the reusable packaging workflow
moved to cibuildwheel v4:

- remove the unsupported `cp313t-*` skip selector;
- rely on cibuildwheel v4's built-in ABI3 audit instead of appending a duplicate
  audit to the repair command.

The generic `cp3??t-*` test skip remains because test dependencies do not yet
provide the required free-threaded wheels. Consequently, `cp314t` continues to
be built but is not tested in the wheel job.

The corresponding migration guidance is documented in
[workflows#424](https://github.com/munich-quantum-toolkit/workflows/pull/424).

## Validation

- `uvx --from cibuildwheel==4.1.0 cibuildwheel --platform macos --print-build-identifiers .`
- `uvx nox --non-interactive -s lint`
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] Tests are not applicable to this build-configuration cleanup.
- [x] Documentation, changelog, and upgrade-guide changes are not needed in
  this consumer repository; migration guidance lives in workflows#424.
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [x] The local validation checks pass.
- [x] I have reviewed the proposed changes.

**If PR contains AI-assisted content:**

- [x] The agent was explicitly authorized to create these pull requests.
- [x] This body begins with the required visible disclosure.
- [x] The AI-assisted commit includes an
  `Assisted-by: GPT-5.6 via Codex` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated
  content, and accept full responsibility for it.
