### PR TITLE
⬆️ Update MQT Templates to v1.4.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,5 +29,5 @@ This checklist serves as a reminder of a couple of things that ensure your pull 
 
 - [ ] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qmap/blob/main/docs/ai_usage.md).
 - [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
-- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
+- [ ] I have disclosed AI assistance in the PR description.
 - [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,51 +5,64 @@ name-template: "MQT QMAP $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🚀 Features and Enhancements"
-    labels:
-      - "enhancement"
-      - "feature"
-      - "refactor"
-      - "usability"
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
+        - "refactor"
+        - "usability"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "bug"
-      - "fix"
+    when:
+      labels:
+        - "bug"
+        - "fix"
   - title: "📄 Documentation"
-    labels:
-      - "documentation"
-  - title: "🤖 CI"
-    labels:
-      - "continuous integration"
+    when:
+      labels:
+        - "documentation"
+  - title: "🤖 CI & Tooling"
+    when:
+      labels:
+        - "continuous integration"
+        - "tooling"
   - title: "📦 Packaging"
-    labels:
-      - "packaging"
+    when:
+      labels:
+        - "packaging"
   - title: "🧹 Code Quality"
-    labels:
-      - "code quality"
+    when:
+      labels:
+        - "code quality"
   - title: "⬆️ Dependencies"
     collapse-after: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "pre-commit"
-      - "submodules"
+    when:
+      labels:
+        - "dependencies"
+        - "github-actions"
+        - "pre-commit"
+        - "submodules"
+  - type: "pre-exclude"
+    when:
+      labels:
+        - "skip-changelog"
+        - "backport"
+        - "release-prep"
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      label: "major"
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "minor"
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "patch"
+  - type: "version-resolver"
+    semver-increment: "patch"
 change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
 change-title-escapes: '\<*_&'
-exclude-labels:
-  - "skip-changelog"
-  - "backport"
-  - "release-prep"
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
 
 template: |
   ## 👀 What Changed

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: munich-quantum-toolkit/templates@02460c7352d8d8a13414c9c082f062b33c3c5ecb # v1.4.1
+      - uses: munich-quantum-toolkit/templates@d0c5adb86d19a5095f871cb6184cfdab298e943c # v1.4.2
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: QMAP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,16 +77,24 @@
   `ty`, formatting, and metadata checks). All hooks must pass before submitting.
 - MUST add or update tests for every code change, even if not explicitly
   requested.
+- MUST place tests in the repository's corresponding test tree, organized by the
+  component that owns the behavior. NEVER place tests or test fixtures in
+  production source or tool directories. Reserve tool- or CLI-level subprocess
+  tests for contracts that cannot be exercised meaningfully through a lower-
+  level public API. Normal test targets and dependencies belong in the test
+  build; avoid promoting an otherwise optional production tool into the default
+  build solely for subprocess testing.
 - MUST follow existing code style by checking neighboring files for patterns.
 - MUST update `CHANGELOG.md` and `UPGRADING.md` when changes are user-facing,
   breaking, or otherwise noteworthy.
 - MUST format changelog entries with the pull request reference and every
   contributing author, for example `([#123]) ([**@username**])`, and define the
   corresponding links at the bottom of `CHANGELOG.md`.
-- MUST include a commit footer attribution in the form
-  `Assisted-by: [Model Name] via [Tool Name]` (example:
-  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`) if AI tools are used to
-  prepare a commit.
+- AI assistance MUST be disclosed in the PR description.
+- Commit-level `Assisted-by: [Model Name] via [Tool Name]` trailers are
+  recommended, not required. For example:
+  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`. Do not rewrite otherwise
+  valid history solely to add one.
 - NEVER modify files that start with "This file has been generated from an
   external template. Please do not modify it directly." These files are managed
   by
@@ -110,6 +118,9 @@
   the disclosure at the beginning of the edited field.
 - MUST keep external communication accurate, specific, and non-repetitive; do
   not post low-quality or unsolicited comments.
+- When reviewing a contribution, MUST focus findings on substantive correctness,
+  contracts, maintainability, tests, documentation, licensing, and validation.
+  NEVER report a missing optional AI-attribution trailer as a review finding.
 
 ### C++
 

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -76,14 +76,16 @@ beginning of the edited field.
 Transparency helps the community understand the role of these tools and develop
 best practices.
 
-**You must disclose AI assistance.** This helps us understand how the tools are
-being used and identify potential issues. Disclose it in the following ways:
+**AI assistance must be disclosed in the PR description.** This helps reviewers
+understand how the tools were used and where human verification was applied.
 
-- **Commit Messages**: Add a trailer to your commit message in the form
-  `Assisted-by: [Model Name] via [Tool Name]` (example:
-  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`)
-- **Public issue and pull request text**: Use the visible disclosure required in
-  the [communication policy](#3-communication).
+- **PR Description**: Briefly state how AI tools materially assisted the
+  contribution. If an agent authored or edited the description, use the visible
+  disclosure required in the [communication policy](#3-communication).
+- **Commit Messages**: We recommend adding an
+  `Assisted-by: [Model Name] via [Tool Name]` trailer to commits prepared with
+  AI assistance. For example:
+  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`.
 
 ### 5. Licensing and Copyright
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -98,9 +98,10 @@ any AI-assisted contribution. In short:
 within an explicitly authorized scope, but you must review their work and remain
 accountable for the result. Every agent-authored or agent-edited public text
 body must begin with `🤖 *AI text below* 🤖`; issue and pull request titles are
-exempt. AI-assisted commits must include an
-`Assisted-by: [Model Name] via [Tool Name]` footer. AI assistance must not be
-used for contributions to issues labeled "good first issue".
+exempt. AI assistance must be disclosed in the PR description. Commit-level
+`Assisted-by: [Model Name] via [Tool Name]` trailers are recommended for commits
+prepared with AI assistance. AI assistance must not be used for contributions to
+issues labeled "good first issue".
 
 If you use an agent, it will automatically read the provided {code}`AGENTS.md`,
 which contains context and instructions to help the agent work on MQT QMAP. For


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Roll out MQT Templates v1.4.2 at exact release commit `d0c5adb86d19a5095f871cb6184cfdab298e943c` and regenerate all enabled templates with the repository workflow inputs.

This updates the Release Drafter category schema, renames the CI category to `CI & Tooling` with the `tooling` label, and synchronizes the current contribution and AI-use guidance.

AI assistance: GPT-5.6 via Codex rendered the released templates, inspected the generated diff, and ran the validation described below.

Validation: the exact-release rerender is stable, `git diff --check` passes, and `uvx nox -s lint` passes.

## Checklist

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide if needed.
- [ ] The changes follow the repository style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [ ] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by the AI Usage Guidelines.
- [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖`.
- [ ] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.